### PR TITLE
Add facets to request

### DIFF
--- a/src/infra/SearchServiceImpl.ts
+++ b/src/infra/SearchServiceImpl.ts
@@ -11,6 +11,7 @@ import Config from '../models/core/Config';
 import VerticalSearchRequest from '../models/searchservice/request/VerticalSearchRequest';
 import VerticalSearchResponse from '../models/searchservice/response/VerticalSearchResponse';
 import serializeStaticFilters from '../serializers/serializeStaticFilters';
+import serializeFacetFilters from '../serializers/serializeFacetFilters';
 
 /**
  * Internal interface representing the query params which may be sent in a universal search
@@ -46,6 +47,7 @@ interface VerticalSearchQueryParams extends QueryParams {
   limit?: number,
   offset?: number,
   retrieveFacets?: boolean,
+  facetFilters?: string,
   skipSpellCheck?: boolean,
   queryTrigger?: QueryTrigger,
   sessionTrackingEnabled?: boolean,
@@ -114,6 +116,7 @@ export default class SearchServiceImpl implements SearchService {
       limit: request.limit,
       offset: request.offset,
       retrieveFacets: request.retrieveFacets,
+      facetFilters: request.facetFilters && serializeFacetFilters(request.facetFilters),
       skipSpellCheck: request.skipSpellCheck,
       queryTrigger: request.queryTrigger,
       sessionTrackingEnabled: request.sessionTrackingEnabled,

--- a/src/models/searchservice/request/VerticalSearchRequest.ts
+++ b/src/models/searchservice/request/VerticalSearchRequest.ts
@@ -16,6 +16,7 @@ export default interface VerticalSearchRequest {
   limit?: number,
   offset?: number,
   retrieveFacets?: boolean,
+  facetFilters?: SimpleFilter[],
   skipSpellCheck?: boolean,
   coordinates?: Coordinates,
   queryTrigger?: QueryTrigger,

--- a/src/serializers/serializeFacetFilters.ts
+++ b/src/serializers/serializeFacetFilters.ts
@@ -1,0 +1,13 @@
+import SimpleFilter from '../models/searchservice/request/SimpleFilter';
+import StaticFilters from '../models/searchservice/request/StaticFilters';
+import { shapeSimpleFilterForApi } from './serializeStaticFilters';
+
+export default function serializeFacetFilters(filters: SimpleFilter[]): string {
+  return JSON.stringify(filters
+    .reduce(function(obj, filter) {
+      const fieldId = filter.fieldId;
+      obj[fieldId] = obj[fieldId] || [];
+      obj[fieldId].push(shapeSimpleFilterForApi(filter));
+      return obj;
+  }, {} as { [key: string]: StaticFilters[] }));
+}

--- a/src/serializers/serializeStaticFilters.ts
+++ b/src/serializers/serializeStaticFilters.ts
@@ -25,7 +25,7 @@ function shapeCombinedFilterForApi(combinedFilter: CombinedFilter): StaticFilter
     : { [combinedFilter.combinator]: shapedFilters };
 }
 
-function shapeSimpleFilterForApi(filter: SimpleFilter): StaticFilters {
+export function shapeSimpleFilterForApi(filter: SimpleFilter): StaticFilters {
   return {
     [filter.fieldId]: {
       [filter.comparator]: filter.comparedValue

--- a/tests/serializers/serializeFacetFilters.ts
+++ b/tests/serializers/serializeFacetFilters.ts
@@ -1,0 +1,24 @@
+import serializeFacetFilters from '../../src/serializers/serializeFacetFilters';
+
+it('serializeFacetFilters serializes facets properly', () => {
+  const actualSerializedFilters = serializeFacetFilters([
+    { fieldId: 'c_jobCategory', comparator: '$eq', comparedValue: 'Sales' },
+    { fieldId: 'c_jobCategory', comparator: '$eq', comparedValue: 'Client Success' },
+    { fieldId: 'c_jobCategory', comparator: '$eq', comparedValue: 'Finance' },
+    { fieldId: 'c_jobLocationShortDescription', comparator: '$eq', comparedValue: 'New York' },
+    { fieldId: 'c_jobLocationShortDescription', comparator: '$eq', comparedValue: 'Chicago' },
+  ]);
+
+  const expectedSerializedFilters = {
+    c_jobCategory: [
+      { c_jobCategory: { $eq: 'Sales' } },
+      { c_jobCategory: { $eq: 'Client Success' } },
+      { c_jobCategory: { $eq: 'Finance' } }
+    ],
+    c_jobLocationShortDescription: [
+      { c_jobLocationShortDescription: { $eq: 'New York' } },
+      { c_jobLocationShortDescription: { $eq: 'Chicago' } }
+    ]
+  };
+  expect(actualSerializedFilters).toEqual(JSON.stringify(expectedSerializedFilters));
+});


### PR DESCRIPTION
Adds facetFilters property to request.

TEST=manual,unit
J=SLAP-849

Wrote unit tests. Additionally, manually tested sending requests with facet filters on a dev Typescript page. Manually tested sending one filter and 5 filters using different fields.