### PR TITLE
Add alternative verticals to vertical search response

### DIFF
--- a/src/models/searchservice/response/VerticalSearchResponse.ts
+++ b/src/models/searchservice/response/VerticalSearchResponse.ts
@@ -14,5 +14,6 @@ export default interface VerticalSearchResponseProps {
   facets?: Readonly<Facet[]>;
   spellCheck?: SpellCheck,
   locationBias?: LocationBias,
-  allResultsForVertical?: VerticalSearchResponseProps
+  allResultsForVertical?: VerticalSearchResponseProps,
+  alternativeVerticals?: Readonly<VerticalResults[]>
 }

--- a/src/transformers/searchservice/createVerticalSearchResponse.ts
+++ b/src/transformers/searchservice/createVerticalSearchResponse.ts
@@ -18,5 +18,7 @@ export default function createVerticalSearchResponse(data: any): Readonly<Vertic
     locationBias: data.response.locationBias && createLocationBias(data.response.locationBias),
     allResultsForVertical: data.response.allResultsForVertical
       && createVerticalSearchResponse({ response: data.response.allResultsForVertical }),
+    alternativeVerticals: data.response.alternativeVerticals && data.response.alternativeVerticals.modules
+      && data.response.alternativeVerticals.modules.map(createVerticalResults),
   });
 }


### PR DESCRIPTION
When there are no results, an "alternativeVerticals" property may be returned from the API with the vertical results for all verticals in the account with the current query. This PR adds support to shape that into our verticalsearchresponse.

TEST=manual
J=SLAP-849

Conduct a search using a Typescript test page, log console output and see alternativeVerticals come through properly.