### PR TITLE
Add entityType and source to the result model

### DIFF
--- a/src/models/searchservice/response/Result.ts
+++ b/src/models/searchservice/response/Result.ts
@@ -1,10 +1,12 @@
 import HighlightedValue from './HighlightedValue';
+import { Source } from './Source';
 
 /**
  * An individual search result
  */
 export default interface Result {
   rawData: Record<string, unknown>;
+  source: Source;
   index?: number;
   name?: string;
   description?: string;
@@ -13,5 +15,5 @@ export default interface Result {
   distance?: number;
   distanceFromFilter?: number;
   highlightedValues?: HighlightedValue[];
-  type?: string;
+  entityType?: string;
 }

--- a/src/models/searchservice/response/Source.ts
+++ b/src/models/searchservice/response/Source.ts
@@ -4,4 +4,5 @@ export enum Source {
   Bing = 'BING_CSE',
   Zendesk = 'ZENDESK',
   Algolia = 'ALGOLIA',
+  Generic = 'GENERIC'
 }

--- a/src/transformers/searchservice/ResultsFactory.ts
+++ b/src/transformers/searchservice/ResultsFactory.ts
@@ -34,6 +34,7 @@ export default class ResultsFactory {
     const rawData = result.data ?? {};
     return Object.freeze({
       rawData: rawData,
+      source: Source.KnowledgeManager,
       index: result.index,
       name: rawData.name,
       description: rawData.description,
@@ -42,13 +43,14 @@ export default class ResultsFactory {
       distance: result.distance,
       distanceFromFilter: result.distanceFromFilter,
       highlightedValues: HighlightedValueFactory.create(result.highlightedFields),
-      type: rawData.type
+      entityType: rawData.type
     });
   }
 
   private static fromGoogleCustomSearchEngine(result: any): Readonly<Result> {
     return Object.freeze({
       rawData: result,
+      source: Source.Google,
       index: result.index,
       name: result.htmlTitle.replace(/(<([^>]+)>)/ig, ''),
       description: result.htmlSnippet,
@@ -59,6 +61,7 @@ export default class ResultsFactory {
   private static fromBingCustomSearchEngine(result: any): Readonly<Result> {
     return Object.freeze({
       rawData: result,
+      source: Source.Bing,
       index: result.index,
       name: result.name,
       description: result.snippet,
@@ -69,6 +72,7 @@ export default class ResultsFactory {
   private static fromZendeskSearchEngine(result: any): Readonly<Result> {
     return Object.freeze({
       rawData: result,
+      source: Source.Zendesk,
       index: result.index,
       name: result.title,
       description: result.snippet,
@@ -79,6 +83,7 @@ export default class ResultsFactory {
   private static fromAlgoliaSearchEngine(result: any): Readonly<Result> {
     return Object.freeze({
       rawData: result,
+      source: Source.Algolia,
       index: result.index,
       name: result.name,
       id: result.objectID
@@ -88,6 +93,7 @@ export default class ResultsFactory {
   private static fromGeneric(result: any): Readonly<Result> {
     return Object.freeze({
       rawData: result,
+      source: Source.Generic,
       index: result.index,
       name: result.name,
       description: result.description, // Do we want to truncate this like in the SDK?
@@ -100,11 +106,12 @@ export default class ResultsFactory {
     const rawData = result.fieldValues ?? {};
     return Object.freeze({
       rawData: rawData,
+      source: Source.KnowledgeManager,
       name: rawData.name,
       description: rawData.description,
       link: result.website,
       id: result.id,
-      type: result.type,
+      entityType: result.type,
     });
   }
 }

--- a/tests/fixtures/coreuniversalresponse.json
+++ b/tests/fixtures/coreuniversalresponse.json
@@ -72,12 +72,14 @@
               "longitude": -70.123456
             }
           },
+          "source": "KNOWLEDGE_MANAGER",
           "index": 1,
           "name": "Bob Smith",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
           "link": "http://www.test.com",
           "id": "Employee-2116",
-          "distance": 36032
+          "distance": 36032,
+          "entityType": "ce_person"
         }
       ],
       "resultsCount": 1,
@@ -95,9 +97,11 @@
             "answer": "Great question! To start, you can **bold,** *italicize,* and ++underline.++ You can also create lists.",
             "name": "Bob loves FAQs"
           },
+          "source": "KNOWLEDGE_MANAGER",
           "index": 1,
           "name": "Bob loves FAQs",
-          "id": "1074283123523689994"
+          "id": "1074283123523689994",
+          "entityType": "faq"
         },
         {
           "rawData": {
@@ -109,9 +113,11 @@
               "Tax"
             ]
           },
+          "source": "KNOWLEDGE_MANAGER",
           "index": 2,
           "name": "Will I need my Federal Tax Identification Number?",
-          "id": "faq-134"
+          "id": "faq-134",
+          "entityType": "faq"
         }
       ],
       "resultsCount": 2,


### PR DESCRIPTION
Add the derived `entityType` field to Results and a `source` field

The `source` field already exists in the `VerticalResults` model, however it may be useful in the `Result` as well

J=none
Test=manual

Update tests to confirm that the fields work properly