### PR TITLE
autocomplete: update autocomplete response domain models

### DIFF
--- a/src/AnswersCore.ts
+++ b/src/AnswersCore.ts
@@ -9,7 +9,7 @@ import QuestionSubmissionRequest from './models/questionsubmission/QuestionSubmi
 import QuestionSubmissionResponse from './models/questionsubmission/QuestionSubmissionResponse';
 import { UniversalAutoCompleteRequest, VerticalAutoCompleteRequest, FilterAutoCompleteRequest }
   from './models/autocompleteservice/AutoCompleteRequest';
-import { AutoCompleteResponse } from './models/autocompleteservice/AutoCompleteResponse';
+import { AutoCompleteResponse, FilterAutoCompleteResponse } from './models/autocompleteservice/AutoCompleteResponse';
 import { AutoCompleteService } from './services/AutoCompleteService';
 
 export default class AnswersCore {
@@ -39,7 +39,7 @@ export default class AnswersCore {
     return this.autoCompleteService.verticalAutoComplete(request);
   }
 
-  filterAutoComplete(request: FilterAutoCompleteRequest): Promise<AutoCompleteResponse> {
+  filterAutoComplete(request: FilterAutoCompleteRequest): Promise<FilterAutoCompleteResponse> {
     return this.autoCompleteService.filterAutoComplete(request);
   }
 }

--- a/src/infra/AutoCompleteServiceImpl.ts
+++ b/src/infra/AutoCompleteServiceImpl.ts
@@ -1,8 +1,8 @@
-import { createAutoCompleteResponse } from '../transformers/autocompleteservice/createAutoCompleteResponse';
+import { createAutoCompleteResponse, createFilterAutoCompleteResponse } from '../transformers/autocompleteservice/createAutoCompleteResponse';
 import { VerticalAutoCompleteRequest, FilterAutoCompleteRequest,
   UniversalAutoCompleteRequest, SearchParameters, SearchParameterField }
   from '../models/autocompleteservice/AutoCompleteRequest';
-import { AutoCompleteResponse } from '../models/autocompleteservice/AutoCompleteResponse';
+import { AutoCompleteResponse, FilterAutoCompleteResponse } from '../models/autocompleteservice/AutoCompleteResponse';
 import { defaultApiVersion, defaultEndpoints } from '../constants';
 import AnswersConfig from '../models/core/AnswersConfig';
 import HttpService from '../services/HttpService';
@@ -104,7 +104,7 @@ export default class AutoCompleteServiceImpl implements AutoCompleteService {
    * @param {FilterAutoCompleteRequest} request
    * @returns {Promise<AutoCompleteResponse>}
    */
-  async filterAutoComplete(request: FilterAutoCompleteRequest): Promise<AutoCompleteResponse> {
+  async filterAutoComplete(request: FilterAutoCompleteRequest): Promise<FilterAutoCompleteResponse> {
     const searchParams = this.getFilterSearchParams(request.searchParameters);
     const queryParams: FilterAutoCompleteQueryParams = {
       input: request.input,
@@ -123,7 +123,7 @@ export default class AutoCompleteServiceImpl implements AutoCompleteService {
       this.filterEndpoint,
       queryParams);
 
-    return createAutoCompleteResponse(rawFilterAutocompleteResponse);
+    return createFilterAutoCompleteResponse(rawFilterAutocompleteResponse);
   }
 
   private getFilterSearchParams(searchParams: SearchParameters) {

--- a/src/models/autocompleteservice/AutoCompleteResponse.ts
+++ b/src/models/autocompleteservice/AutoCompleteResponse.ts
@@ -7,6 +7,17 @@ export interface AutoCompleteResponse {
   queryId?: string;
 }
 
+export interface FilterAutoCompleteResponse {
+  sectioned: boolean,
+  sections?: {
+    label: string,
+    results: AutoCompleteResult[];
+  }[],
+  results?: AutoCompleteResult[],
+  inputIntents: SearchIntent[];
+  queryId?: string
+}
+
 export interface AutoCompleteResult {
   value: string;
   filter?: SimpleFilter;

--- a/src/services/AutoCompleteService.ts
+++ b/src/services/AutoCompleteService.ts
@@ -1,4 +1,4 @@
-import { AutoCompleteResponse } from '../models/autocompleteservice/AutoCompleteResponse';
+import { AutoCompleteResponse, FilterAutoCompleteResponse } from '../models/autocompleteservice/AutoCompleteResponse';
 import { UniversalAutoCompleteRequest, FilterAutoCompleteRequest, VerticalAutoCompleteRequest } from '../models/autocompleteservice/AutoCompleteRequest';
 
 /**
@@ -26,7 +26,7 @@ export interface AutoCompleteService {
    * Retrieves query suggestions for filter search.
    *
    * @param {FilterAutoCompleteRequest} request
-   * @returns {Promise<AutoCompleteResponse>}
+   * @returns {Promise<FilterAutoCompleteResponse>}
    */
-  filterAutoComplete(request: FilterAutoCompleteRequest): Promise<AutoCompleteResponse>;
+  filterAutoComplete(request: FilterAutoCompleteRequest): Promise<FilterAutoCompleteResponse>;
  }

--- a/tests/fixtures/autocompleteresponsewithsections.json
+++ b/tests/fixtures/autocompleteresponsewithsections.json
@@ -3,6 +3,7 @@
     "businessId": 2287528,
     "sections": [
       {
+        "label": "Name",
         "results": [
           {
             "key": "name",

--- a/tests/infra/AutoCompleteServiceImpl.ts
+++ b/tests/infra/AutoCompleteServiceImpl.ts
@@ -5,7 +5,7 @@ import HttpService from '../../src/services/HttpService';
 import AutoCompleteServiceImpl from '../../src/infra/AutoCompleteServiceImpl';
 import mockAutoCompleteResponse from '../fixtures/autocompleteresponse.json';
 import mockAutoCompleteResponseWithSections from '../fixtures/autocompleteresponsewithsections.json';
-import { createAutoCompleteResponse } from '../../src/transformers/autocompleteservice/createAutoCompleteResponse';
+import { createAutoCompleteResponse, createFilterAutoCompleteResponse } from '../../src/transformers/autocompleteservice/createAutoCompleteResponse';
 import { defaultEndpoints } from '../../src/constants';
 import { SearchIntent } from '../../src/models/searchservice/response/SearchIntent';
 
@@ -20,8 +20,8 @@ describe('AutoCompleteService', () => {
 
   describe('Universal AutoComplete', () => {
     const expectedUniversalUrl = defaultEndpoints.universalAutoComplete;
-    mockHttpService.get.mockResolvedValue(mockAutoCompleteResponse);
     it('query params are correct', async () => {
+      mockHttpService.get.mockResolvedValue(mockAutoCompleteResponse);
       const request: UniversalAutoCompleteRequest = {
         input: '',
         sessionTrackingEnabled: false
@@ -45,8 +45,8 @@ describe('AutoCompleteService', () => {
 
   describe('Vertical AutoComplete', () => {
     const expectedVerticalUrl = defaultEndpoints.verticalAutoComplete;
-    mockHttpService.get.mockResolvedValue(mockAutoCompleteResponse);
     it('query params are correct', async () => {
+      mockHttpService.get.mockResolvedValue(mockAutoCompleteResponse);
       const request: VerticalAutoCompleteRequest = {
         input: 'salesforce',
         sessionTrackingEnabled: false,
@@ -72,8 +72,8 @@ describe('AutoCompleteService', () => {
 
   describe('Filter AutoComplete', () => {
     const expectedFilterUrl = defaultEndpoints.filterAutoComplete;
-    mockHttpService.get.mockResolvedValue(mockAutoCompleteResponseWithSections);
     it('query params are correct', async () => {
+      mockHttpService.get.mockResolvedValue(mockAutoCompleteResponseWithSections);
       const searchParams: SearchParameters = {
         sectioned: false,
           fields: [{
@@ -137,27 +137,34 @@ describe('AutoCompleteService', () => {
 
     it('response with sections is parsed correctly', () => {
       const expectedResponse = {
+        sectioned: true,
+        sections: [
+          {
+            label: 'Name',
+            results: [
+              {
+                value: 'Virginia Beach',
+                matchedSubstrings: [
+                  {
+                    offset: 0,
+                    length: 8
+                  }
+                ],
+                filter: {
+                  comparator: '$eq',
+                  comparedValue: 'Virginia Beach',
+                  fieldId: 'name'
+                },
+                key: 'name'
+              }
+            ]
+          }
+        ],
+        results: [],
         inputIntents: [],
         queryId: '42d5b709-3b9f-464a-b9b5-764467cbf540',
-        results: [
-          {
-            value: 'Virginia Beach',
-            matchedSubstrings: [
-              {
-                offset: 0,
-                length: 8
-              }
-            ],
-            filter: {
-              comparator: '$eq',
-              comparedValue: 'Virginia Beach',
-              fieldId: 'name'
-            },
-            key: 'name'
-          }
-        ]
       };
-      const actualResponse = createAutoCompleteResponse(mockAutoCompleteResponseWithSections);
+      const actualResponse = createFilterAutoCompleteResponse(mockAutoCompleteResponseWithSections);
       expect(actualResponse).toEqual(expectedResponse);
     });
   });


### PR DESCRIPTION
Adds a FilterAutoCompleteResponse to the domain model.
This new model has a sections field that will accommodate
filter autocomplete responses from the backend that contain
a `sections` object.

The presense of a `sections` object is determined by the
`sectioned` field in search paramters in a FilterAutoCompleteRequest.
If `sectioned: true` is passed, then the results from the backend
are grouped by the fields passed in the search paramters.

Updates automated tests to match the new response domain model.

TEST=auto, manual
Ran automated tests and saw them pass.
Used the core testing library with filter autocomplete requests
and saw that the results are parsed correctly.