### PR TITLE
autocomplete: handle entities in filter response

### DIFF
--- a/src/models/autocompleteservice/AutoCompleteResponse.ts
+++ b/src/models/autocompleteservice/AutoCompleteResponse.ts
@@ -27,4 +27,8 @@ export interface AutoCompleteResult {
     offset: number
   }[];
   shortValue?: string;
+  relatedItem?: {
+    data: Record<string, unknown>,
+    highlightedFields: Record<string, unknown>
+  };
 }

--- a/src/transformers/autocompleteservice/createAutoCompleteResponse.ts
+++ b/src/transformers/autocompleteservice/createAutoCompleteResponse.ts
@@ -3,7 +3,10 @@ import { createAutoCompleteResult } from './createAutoCompleteResult';
 
 export function createAutoCompleteResponse(data: any): Readonly<AutoCompleteResponse> {
   if (!data.response) {
-    throw new Error('The search data does not contain a response property');
+    throw new Error('The autocomplete data does not contain a response property');
+  }
+  if (!Object.keys(data.response).length) {
+    throw new Error('The autocomplete response is empty');
   }
 
   const response = data.response;
@@ -18,7 +21,10 @@ export function createAutoCompleteResponse(data: any): Readonly<AutoCompleteResp
 
 export function createFilterAutoCompleteResponse(data: any): Readonly<FilterAutoCompleteResponse> {
   if (!data.response) {
-    throw new Error('The search data does not contain a response property');
+    throw new Error('The autocomplete data does not contain a response property');
+  }
+  if (!Object.keys(data.response).length) {
+    throw new Error('The autocomplete response is empty');
   }
 
   const response = data.response;

--- a/src/transformers/autocompleteservice/createAutoCompleteResult.ts
+++ b/src/transformers/autocompleteservice/createAutoCompleteResult.ts
@@ -7,6 +7,7 @@ export function createAutoCompleteResult(results: any): AutoCompleteResult {
     key: results.key,
     matchedSubstrings: results.matchedSubstrings || [],
     value: results.value,
-    shortValue: results.shortValue
+    shortValue: results.shortValue,
+    relatedItem: results.relatedItem
   });
 }

--- a/tests/fixtures/autocompleteresponsewithentities.json
+++ b/tests/fixtures/autocompleteresponsewithentities.json
@@ -1,0 +1,60 @@
+{
+  "response": {
+    "businessId": 2287528,
+    "sections": [
+      {
+        "label": "Name",
+        "results": [
+          {
+            "key": "name",
+            "value": "Virginia Beach",
+            "filter": {
+              "name": {
+                "$eq": "Virginia Beach"
+              }
+            },
+            "matchedSubstrings": [
+              {
+                "offset": 0,
+                "length": 8
+              }
+            ],
+            "relatedItem": {
+              "data": {
+                "mock": "data"
+              },
+              "highlightedFields": {
+                "mock": "field"
+              }
+            }
+          },
+          {
+            "key": "name",
+            "value": "Virginia Beach",
+            "filter": {
+              "name": {
+                "$eq": "Virginia Beach"
+              }
+            },
+            "matchedSubstrings": [
+              {
+                "offset": 0,
+                "length": 8
+              }
+            ],
+            "relatedItem": {
+              "data": {
+                "mock": "data2"
+              },
+              "highlightedFields": {
+                "mock": "field2"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "failedVerticals": [],
+    "queryId": "42d5b709-3b9f-464a-b9b5-764467cbf540"
+  }
+}

--- a/tests/infra/AutoCompleteServiceImpl.ts
+++ b/tests/infra/AutoCompleteServiceImpl.ts
@@ -5,6 +5,7 @@ import HttpService from '../../src/services/HttpService';
 import AutoCompleteServiceImpl from '../../src/infra/AutoCompleteServiceImpl';
 import mockAutoCompleteResponse from '../fixtures/autocompleteresponse.json';
 import mockAutoCompleteResponseWithSections from '../fixtures/autocompleteresponsewithsections.json';
+import mockAutoCompleteResponseWithEntities from '../fixtures/autocompleteresponsewithentities.json';
 import { createAutoCompleteResponse, createFilterAutoCompleteResponse } from '../../src/transformers/autocompleteservice/createAutoCompleteResponse';
 import { defaultEndpoints } from '../../src/constants';
 import { SearchIntent } from '../../src/models/searchservice/response/SearchIntent';
@@ -165,6 +166,70 @@ describe('AutoCompleteService', () => {
         queryId: '42d5b709-3b9f-464a-b9b5-764467cbf540',
       };
       const actualResponse = createFilterAutoCompleteResponse(mockAutoCompleteResponseWithSections);
+      expect(actualResponse).toEqual(expectedResponse);
+    });
+
+    it ('response with sections and entities fetched is parsed correctly', () => {
+      const expectedResponse = {
+        sectioned: true,
+        sections: [
+          {
+            label: 'Name',
+            results: [
+              {
+                value: 'Virginia Beach',
+                matchedSubstrings: [
+                  {
+                    offset: 0,
+                    length: 8
+                  }
+                ],
+                filter: {
+                  comparator: '$eq',
+                  comparedValue: 'Virginia Beach',
+                  fieldId: 'name'
+                },
+                key: 'name',
+                relatedItem: {
+                  data: {
+                    mock: 'data'
+                  },
+                  highlightedFields: {
+                    mock: 'field'
+                  }
+                }
+              },
+              {
+                value: 'Virginia Beach',
+                matchedSubstrings: [
+                  {
+                    offset: 0,
+                    length: 8
+                  }
+                ],
+                filter: {
+                  comparator: '$eq',
+                  comparedValue: 'Virginia Beach',
+                  fieldId: 'name'
+                },
+                key: 'name',
+                relatedItem: {
+                  data: {
+                    mock: 'data2'
+                  },
+                  highlightedFields: {
+                    mock: 'field2'
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        results: [],
+        inputIntents: [],
+        queryId: '42d5b709-3b9f-464a-b9b5-764467cbf540',
+      };
+      const actualResponse = createFilterAutoCompleteResponse(mockAutoCompleteResponseWithEntities);
       expect(actualResponse).toEqual(expectedResponse);
     });
   });


### PR DESCRIPTION
Adds code to handle when entities are returned as part of a
filter autocomplete response.

Filter autocomplete responses will return entity information
if `fetchEntities` in the search paramters is set to `true`.
In a result object, the entity information will be in a
relatedItem object. We add code to handle and return the
relatedItem object in a result.

Adds an automated test case that tests parsing of a response
with mock entity information.

TEST=auto, manual
Ran automated tests and saw them pass.
Used the core test library to send autocomplete requests and
saw that the responses are what we expect.