### PR TITLE
Ensure that Core can be used within a Node application.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2787,7 +2787,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
       "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
-      "dev": true,
       "requires": {
         "node-fetch": "2.6.1"
       }
@@ -5834,8 +5833,7 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -7822,11 +7820,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "whatwg-fetch": "^3.4.1"
+    "cross-fetch": "^3.0.6"
   },
   "jest": {
     "bail": 0,

--- a/src/infra/HttpServiceImpl.ts
+++ b/src/infra/HttpServiceImpl.ts
@@ -1,4 +1,4 @@
-import { fetch as fetchPolyfill } from 'whatwg-fetch';
+import fetch from 'cross-fetch';
 import { addParamsToURL, sanitizeQueryParams } from '../utils/urlutils';
 import { QueryParams } from '../models/http/params';
 import { HttpService } from '../services/HttpService';
@@ -60,9 +60,6 @@ export class HttpServiceImpl implements HttpService {
     reqInit: RequestInit
   ): Promise<Response> {
     const urlWithParams = addParamsToURL(url, queryParams);
-    if (!window.fetch) {
-      return fetchPolyfill(urlWithParams, reqInit);
-    }
     return fetch(urlWithParams, reqInit);
   }
 }

--- a/tests/infra/HttpServiceImpl.js
+++ b/tests/infra/HttpServiceImpl.js
@@ -1,9 +1,16 @@
+import fetch from 'cross-fetch';
+
 import { HttpServiceImpl } from '../../src/infra/HttpServiceImpl';
 
+jest.mock('cross-fetch');
+
 describe('HttpServiceImpl', () => {
-    const httpServiceImpl = new HttpServiceImpl();
+  const httpServiceImpl = new HttpServiceImpl();
+  fetch.mockResolvedValue({
+    json: () => []
+  });
+
   it('can make get requests', async () => {
-    fetch.mockResponseOnce('{}');
     const queryParams = {
       aQuery: 'param'
     };
@@ -19,7 +26,6 @@ describe('HttpServiceImpl', () => {
   });
 
   it('can make post requests', async () => {
-    fetch.mockResponseOnce('{}');
     const jsonBody = {
       data: '123'
     };


### PR DESCRIPTION
Previously, Core was not able to be used within a Node app. This was because
we used whatwg-fetch. This library only works within the Browser. It provides
a polyfill of window.fetch. We now use cross-fetch, which provides a platform
agnostic ponyfill of fetch.

Note that the ponyfill is always used. It is not guarded by a check for
window.fetch. Having this check, as we did before, adds complexity to the code.
It does not make any resulting bundle smaller.

I verified that the cross-fetch library did not appreciably increase the size
of the answers-core-testing bundle. So, bundle size should not be noticeably
impacted. As a side benefit, because we're using a ponyfill, Core will not be
polluting the global namespace.

In another PR, I can update the answers-core-testing library to have a Node
application.

J=SLAP-1012
TEST=manual

Verified the following:

- The various tests in the answers-core-testing library still worked as
  expected. This implies that Core still works properly in the Browser.
- Created a Node application that uses all the different Core methods. Things
  worked as expected.