### PR TITLE
Make context optional

### DIFF
--- a/docs/answers-core.verticalsearchrequest.context.md
+++ b/docs/answers-core.verticalsearchrequest.context.md
@@ -9,7 +9,7 @@ Used to trigger Answers [Query Rules](https://hitchhikers.yext.com/tracks/answer
 <b>Signature:</b>
 
 ```typescript
-context: Context;
+context?: Context;
 ```
 
 ## Remarks

--- a/docs/answers-core.verticalsearchrequest.md
+++ b/docs/answers-core.verticalsearchrequest.md
@@ -16,7 +16,7 @@ export interface VerticalSearchRequest
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [context](./answers-core.verticalsearchrequest.context.md) | [Context](./answers-core.context.md) | Used to trigger Answers [Query Rules](https://hitchhikers.yext.com/tracks/answers-advanced/ans302-query-rules/)<!-- -->. |
+|  [context?](./answers-core.verticalsearchrequest.context.md) | [Context](./answers-core.context.md) | <i>(Optional)</i> Used to trigger Answers [Query Rules](https://hitchhikers.yext.com/tracks/answers-advanced/ans302-query-rules/)<!-- -->. |
 |  [coordinates?](./answers-core.verticalsearchrequest.coordinates.md) | Coordinates | <i>(Optional)</i> The coordinates of the user making the request which is used to bias the results. |
 |  [facetFilters?](./answers-core.verticalsearchrequest.facetfilters.md) | [SimpleFilter](./answers-core.simplefilter.md)<!-- -->\[\] | <i>(Optional)</i> The facet filters to apply to the search. |
 |  [limit?](./answers-core.verticalsearchrequest.limit.md) | number | <i>(Optional)</i> The maximum number of results to include with a max of 50. |

--- a/etc/answers-core.api.md
+++ b/etc/answers-core.api.md
@@ -333,7 +333,7 @@ export interface VerticalResults {
 
 // @public
 export interface VerticalSearchRequest {
-    context: Context;
+    context?: Context;
     coordinates?: Coordinates_2;
     facetFilters?: SimpleFilter[];
     limit?: number;

--- a/src/models/searchservice/request/VerticalSearchRequest.ts
+++ b/src/models/searchservice/request/VerticalSearchRequest.ts
@@ -17,7 +17,7 @@ export interface VerticalSearchRequest {
   /** The key associated with the vertical. */
   verticalKey: string,
   /** {@inheritDoc Context} */
-  context: Context,
+  context?: Context,
   /** The maximum number of results to include with a max of 50. */
   limit?: number,
   /** The result offset which allows for fetching more results with the same query. */

--- a/src/transformers/searchservice/ResultsFactory.ts
+++ b/src/transformers/searchservice/ResultsFactory.ts
@@ -7,6 +7,10 @@ import { HighlightedValueFactory } from './HighlightedValueFactory';
  */
 export class ResultsFactory {
   public static create(results: any, source: Source): Result[] {
+    if (!results) {
+      return [];
+    }
+
     return results.map((result: any, index: number) => {
       result = {
         ...result,

--- a/src/transformers/searchservice/createFacets.ts
+++ b/src/transformers/searchservice/createFacets.ts
@@ -2,6 +2,10 @@ import { Facet, FacetOption } from '../../models/searchservice/response/Facet';
 import { createSimpleFilter } from '../core/createSimpleFilter';
 
 export function createFacets(facets: any): Readonly<Facet[]> {
+  if (!facets) {
+    return [];
+  }
+
   return Object.freeze(facets.map((facet: any) => ({
     fieldId: facet.fieldId,
     displayName: facet.displayName,

--- a/src/transformers/searchservice/createVerticalResults.ts
+++ b/src/transformers/searchservice/createVerticalResults.ts
@@ -3,7 +3,9 @@ import { createAppliedQueryFilter } from './createAppliedQueryFilter';
 import { VerticalResults } from '../../models/searchservice/response/VerticalResults';
 
 export function createVerticalResults(data: any): Readonly<VerticalResults> {
-  const appliedQueryFilters = data.appliedQueryFilters.map(createAppliedQueryFilter);
+  const appliedQueryFilters = data.appliedQueryFilters
+    ? data.appliedQueryFilters.map(createAppliedQueryFilter)
+    : [];
 
   return Object.freeze({
     appliedQueryFilters: appliedQueryFilters,

--- a/tests/infra/SearchServiceImpl.ts
+++ b/tests/infra/SearchServiceImpl.ts
@@ -6,10 +6,9 @@ import { UniversalSearchRequest } from '../../src/models/searchservice/request/U
 import { HttpService } from '../../src/services/HttpService';
 import { QueryTrigger } from '../../src/models/searchservice/request/QueryTrigger';
 import { QuerySource } from '../../src/models/searchservice/request/QuerySource';
+import { VerticalSearchRequest } from '../../src/models/searchservice/request/VerticalSearchRequest';
 
 describe('SearchService', () => {
-  const mockHttpService = new HttpServiceMock();
-
   const configWithRequiredParams: AnswersConfig = {
     apiKey: 'testApiKey',
     experienceKey: 'testExperienceKey',
@@ -17,6 +16,7 @@ describe('SearchService', () => {
   };
 
   describe('Universal Search', () => {
+    const mockHttpService = new HttpServiceMock();
     mockHttpService.get.mockResolvedValue(mockUniversalResponse);
     const expectedUniversalUrl = 'https://liveapi.yext.com/v2/accounts/me/answers/query';
 
@@ -99,6 +99,38 @@ describe('SearchService', () => {
       );
       await searchService.universalSearch({query: 'test'});
       expect(mockHttpService.get).toHaveBeenCalledWith(expectedUniversalUrl, expect.anything());
+    });
+  });
+
+  describe('Vertical Search', ()=> {
+    const mockHttpService = new HttpServiceMock();
+    mockHttpService.get.mockResolvedValue({
+      response: {},
+      meta: {},
+    });
+    const expectedVerticalUrl = 'https://liveapi.yext.com/v2/accounts/me/answers/vertical/query';
+
+    it('Query params are correct when only required params are supplied', async () => {
+      const requestWithRequiredParams: VerticalSearchRequest = {
+        query: 'testQuery',
+        verticalKey: 'verticalKey'
+      };
+      const expectedQueryParams = {
+        api_key: 'testApiKey',
+        experienceKey: 'testExperienceKey',
+        verticalKey: 'verticalKey',
+        input: 'testQuery',
+        locale: 'en',
+        v: 20190101,
+        source: 'STANDARD',
+        sortBys: '[]',
+      };
+      const searchService = new SearchServiceImpl(
+        configWithRequiredParams,
+        mockHttpService as HttpService
+      );
+      await searchService.verticalSearch(requestWithRequiredParams);
+      expect(mockHttpService.get).toHaveBeenCalledWith(expectedVerticalUrl, expectedQueryParams);
     });
   });
 });


### PR DESCRIPTION
Ensure that a vertical request can be sent without requiring context

In order to make the test pass, I updated a few of the transformers to be more resilient to missing response data

J=SLAP-1011
TEST=manual, auto

Test all requests with the answers core library and ensure that none of them require the context param. Add a test for vertical search that verifies that the minimum required params are query and vertical key.