### PR TITLE
Update readme for v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
 
 Answers Core is a networking library for interacting with the Yext Answers API.
 
+[Full Documentation](https://github.com/yext/answers-core/blob/master/docs/answers-core.md)
+
 ## Features
 
 - Works in both the **browser** and **Node.js**
 - 100% **TypeScript**, with detailed request and response models
 - Compatible with both **CommonJS** and **ES6** imports
 - Offers a ponyfilled ES5 bundle which doesn't pollute the global namespace
-
-[Full Documentation](https://github.com/yext/answers-core/blob/master/docs/answers-core.md)
 
 ## Getting Started
 


### PR DESCRIPTION
Release Notes for v1.0.0:

## Version 1.0.0
Answers-core is a networking library for interacting with the Yext Answers API:
- Works in both the browser and Node.js
- 100% TypeScript, with detailed request and response models
- Compatible with both CommonJS and ES6 imports
- Offers a ponyfilled ES5 bundle, that doesn't pollute the global namespace

J=SLAP-840, SLAP-1067
TEST=manual

checked the readme on the dev/readme-update github branch 
(https://github.com/yext/answers-core/tree/dev/readme-update)
ran test publish to a beta tag, checked npm readme
https://www.npmjs.com/package/@yext/answers-core/v/1.0.0-beta.2
tested the answers-core-testing lib in ie11 using v1.0.0-beta.2 by importing from @yext/answers-core/legacy
saw that trying to use @yext/answers-core would fail and using legacy would work (after updating answers-core-testing
to be es5)