### PR TITLE
Fix erroring out for allResultsForVertical and alternativeVerticals

### DIFF
--- a/src/transformers/searchservice/createVerticalSearchResponse.ts
+++ b/src/transformers/searchservice/createVerticalSearchResponse.ts
@@ -20,6 +20,6 @@ export function createVerticalSearchResponse(data: any): VerticalSearchResponse 
       && createVerticalSearchResponse({ response: data.response.allResultsForVertical }),
     alternativeVerticals: data.response.alternativeVerticals && data.response.alternativeVerticals.modules
       && data.response.alternativeVerticals.modules.map(createVerticalResults),
-    uuid: data.meta.uuid
+    uuid: data.meta?.uuid
   };
 }

--- a/tests/transformers/searchservice/createVerticalSearchResponse.ts
+++ b/tests/transformers/searchservice/createVerticalSearchResponse.ts
@@ -1,0 +1,32 @@
+import { createVerticalSearchResponse } from '../../../src/transformers/searchservice/createVerticalSearchResponse';
+
+it('can handle allResultsForVertical', () => {
+  const rawResponse = {
+    response: {
+      allResultsForVertical: {
+        resultsCount: 1,
+        source: 'KNOWLEDGE_MANAGER',
+        results: [
+          {
+            data: 'mockdata',
+          }
+        ]
+      }
+    }
+  };
+  const transformedResponse = createVerticalSearchResponse(rawResponse);
+  expect(transformedResponse).toMatchObject({
+    allResultsForVertical: {
+      verticalResults: {
+        appliedQueryFilters: [],
+        results: [
+          {
+            index: 1,
+            rawData: 'mockdata',
+            source: 'KNOWLEDGE_MANAGER'
+          },
+        ]
+      }
+    }
+  });
+});


### PR DESCRIPTION
The library was erroring out when a vertical search
returned allResultsForVertical or alternativeVerticals.
This was because it expected it was using createVerticalSearchResponse
on these two properties of the response, and by doing so tried to access
a data.meta.uuid property when data.meta is not defined for these two
properties.

TEST=manual, auto

test that I can do a no results search in answers-core-testing