### PR TITLE
Use files property in package.json instead of npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-tests/
-src/

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./dist/bundle.d.ts",
+  "files": [
+    "dist",
+    "legacy",
+    "lib"
+  ],
   "engines": {
     "node": ">=0.12"
   },


### PR DESCRIPTION
It's a little simpler to use the files property instead of
npmignore, because of weird interactions npmignore has
with gitignore (i.e. not respecting gitignore).

This reduces our unpacked size on npm from 1.8MB to 1.25MB
since we're no longer including docs (and a few other things)
 in our package.

J=SLAP-840
TEST=manual

tried a local npm install in answers-core-testing, but
it looks like the files property doesn't affect local
npm installs

did a test publish to v1.0.0-beta.6 and npm install of the beta
saw that dist, lib, and legacy folders were the only things
when I npm install-ed the package
tested that importing from `@yext/answers-core/legacy` works in ie11