### PR TITLE
Target ES5 with the ESM Build

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es2015",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "target": "es2015",
     "module": "commonjs",
     "outDir": "lib/commonjs"
   }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "target": "es5",
     "module": "es6",
     "outDir": "lib/esm"
   }


### PR DESCRIPTION
Target ES5 with the ESM build

This PR makes the ESM build compatible with IE11 so long as polyfills are present. Previously, the library would need to be transpiled to ES5 and have polyfills added.

J=SLAP-1074
TEST=manual

Set the core library target to ES5 and include this branch of the core. Remove babel from the build and add `import 'core/js'` to the testing library index. Confirm that the site works on IE11 and Chrome