### PR TITLE
Handle highlighted fields with arrays

### DIFF
--- a/docs/answers-core.highlightedvalue.path.md
+++ b/docs/answers-core.highlightedvalue.path.md
@@ -26,3 +26,15 @@ In the knowledge graph a field may be nested in a structure such as:
 ```
 The associated path would then be `['description', 'featured']`
 
+If there are multiple highlighted values for a single field, they will have the same path.
+
+```
+{
+  description: {
+    featured: ['The offical answers engine', 'gives you answers']
+  }
+}
+
+```
+The associated path for both values would be `['description', 'featured']`<!-- -->.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.0",
   "description": "Typescript Networking Library for the Yext Answers API",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",

--- a/src/models/searchservice/response/HighlightedValue.ts
+++ b/src/models/searchservice/response/HighlightedValue.ts
@@ -23,6 +23,17 @@ export interface HighlightedValue {
    * }
    * ```
    * The associated path would then be `['description', 'featured']`
+   *
+   * If there are multiple highlighted values for a single field, they will have the same path.
+   *
+   * ```
+   * {
+   *   description: {
+   *     featured: ['The offical answers engine', 'gives you answers']
+   *   }
+   * }
+   * ```
+   * The associated path for both values would be `['description', 'featured']`.
    */
   path: string[],
   /**

--- a/src/transformers/searchservice/HighlightedValueFactory.ts
+++ b/src/transformers/searchservice/HighlightedValueFactory.ts
@@ -37,12 +37,17 @@ export class HighlightedValueFactory {
 
     const highlightedValues: HighlightedValue[] = [];
 
-    Object.entries(data).forEach(([fieldName, highlightedField]) => {
+    Object.entries(data).forEach(([fieldName, highlightedFieldData]) => {
       const currentPath = [...path];
       currentPath.push(fieldName);
 
-      if (this.isChildHighlightedField(highlightedField)) {
-        const { value, matchedSubstrings } = highlightedField;
+      if (Array.isArray(highlightedFieldData)) {
+        const highlightedValuesFromArray = highlightedFieldData.map(({ value, matchedSubstrings }) => {
+          return this.from(value, fieldName, currentPath, matchedSubstrings);
+        });
+        highlightedValues.push(...highlightedValuesFromArray);
+      } else if (this.isChildHighlightedField(highlightedFieldData)) {
+        const { value, matchedSubstrings } = highlightedFieldData;
 
         const highlightedValue = this.from(value, fieldName, currentPath, matchedSubstrings);
         highlightedValues.push(highlightedValue);

--- a/src/transformers/searchservice/HighlightedValueFactory.ts
+++ b/src/transformers/searchservice/HighlightedValueFactory.ts
@@ -34,29 +34,22 @@ export class HighlightedValueFactory {
     if (typeof data !== 'object' || data === null){
       return [];
     }
+    if (this.isChildHighlightedField(data)) {
+      return [ this.from(data.value, path[path.length - 1], path, data.matchedSubstrings) ];
+    }
 
     const highlightedValues: HighlightedValue[] = [];
-
-    Object.entries(data).forEach(([fieldName, highlightedFieldData]) => {
-      const currentPath = [...path];
-      currentPath.push(fieldName);
-
-      if (Array.isArray(highlightedFieldData)) {
-        const highlightedValuesFromArray = highlightedFieldData.map(({ value, matchedSubstrings }) => {
-          return this.from(value, fieldName, currentPath, matchedSubstrings);
-        });
-        highlightedValues.push(...highlightedValuesFromArray);
-      } else if (this.isChildHighlightedField(highlightedFieldData)) {
-        const { value, matchedSubstrings } = highlightedFieldData;
-
-        const highlightedValue = this.from(value, fieldName, currentPath, matchedSubstrings);
-        highlightedValues.push(highlightedValue);
-      } else {
+    if (Array.isArray(data)) {
+      data.forEach(d => {
+        highlightedValues.push(...this.createRecursively(d, path));
+      });
+    } else {
+      Object.keys(data).forEach(fieldName => {
+        const currentPath = [...path, fieldName];
         const nestedHighlightedValues = this.createRecursively(data[fieldName], currentPath);
         highlightedValues.push(...nestedHighlightedValues);
-      }
-    });
-
+      });
+    }
     return highlightedValues;
   }
 

--- a/tests/transformers/HighlightedValueFactory.ts
+++ b/tests/transformers/HighlightedValueFactory.ts
@@ -88,7 +88,7 @@ it('Nested highlighted fields', () => {
   expect(actualHighlightedValues).toMatchObject(expectedHighlightedValues);
 });
 
-it('Highlighted fields with an array of data', () => {
+it('Highlighted fields with arrays', () => {
   const liveApiData = {
     languages: [
       {
@@ -131,22 +131,32 @@ it('Highlighted fields with an array of data', () => {
   expect(actualHighlightedValues).toMatchObject(expectedHighlightedValues);
 });
 
-it('Highlighted fields with a nested array of data', () => {
+it('Highlighted fields with arbitrarily nested arrays', () => {
   const liveApiData = {
     featured: {
       languages: [
         {
-          value: 'English',
-          matchedSubstrings: []
+          superDuper: [
+            {
+              value: 'super',
+              matchedSubstrings: []
+            },
+            {
+              value: 'deeduper',
+              matchedSubstrings: []
+            }
+          ],
         },
         {
-          value: 'Spanish',
-          matchedSubstrings: [
-            {
-              offset: 0,
-              length: 7
-            }
-          ]
+          reallyAwesome: {
+            value: 'Spanish',
+            matchedSubstrings: [
+              {
+                offset: 0,
+                length: 7
+              }
+            ]
+          }
         }
       ]
     }
@@ -154,15 +164,21 @@ it('Highlighted fields with a nested array of data', () => {
 
   const expectedHighlightedValues = [
     {
-      fieldName: 'languages',
-      value: 'English',
-      path: ['featured', 'languages'],
+      fieldName: 'superDuper',
+      value: 'super',
+      path: ['featured', 'languages', 'superDuper'],
       matchedSubstrings: []
     },
     {
-      fieldName: 'languages',
+      fieldName: 'superDuper',
+      value: 'deeduper',
+      path: ['featured', 'languages', 'superDuper'],
+      matchedSubstrings: []
+    },
+    {
+      fieldName: 'reallyAwesome',
       value: 'Spanish',
-      path: ['featured', 'languages'],
+      path: ['featured', 'languages', 'reallyAwesome'],
       matchedSubstrings: [
         {
           offset: 0,
@@ -171,7 +187,6 @@ it('Highlighted fields with a nested array of data', () => {
       ]
     }
   ];
-
   const actualHighlightedValues = HighlightedValueFactory.create(liveApiData);
   expect(actualHighlightedValues).toMatchObject(expectedHighlightedValues);
 });

--- a/tests/transformers/HighlightedValueFactory.ts
+++ b/tests/transformers/HighlightedValueFactory.ts
@@ -87,3 +87,91 @@ it('Nested highlighted fields', () => {
 
   expect(actualHighlightedValues).toMatchObject(expectedHighlightedValues);
 });
+
+it('Highlighted fields with an array of data', () => {
+  const liveApiData = {
+    languages: [
+      {
+        value: 'English',
+        matchedSubstrings: []
+      },
+      {
+        value: 'Spanish',
+        matchedSubstrings: [
+          {
+            offset: 0,
+            length: 7
+          }
+        ]
+      }
+    ]
+  };
+
+  const expectedHighlightedValues = [
+    {
+      fieldName: 'languages',
+      value: 'English',
+      path: ['languages'],
+      matchedSubstrings: []
+    },
+    {
+      fieldName: 'languages',
+      value: 'Spanish',
+      path: ['languages'],
+      matchedSubstrings: [
+        {
+          offset: 0,
+          length: 7
+        }
+      ]
+    }
+  ];
+
+  const actualHighlightedValues = HighlightedValueFactory.create(liveApiData);
+  expect(actualHighlightedValues).toMatchObject(expectedHighlightedValues);
+});
+
+it('Highlighted fields with a nested array of data', () => {
+  const liveApiData = {
+    featured: {
+      languages: [
+        {
+          value: 'English',
+          matchedSubstrings: []
+        },
+        {
+          value: 'Spanish',
+          matchedSubstrings: [
+            {
+              offset: 0,
+              length: 7
+            }
+          ]
+        }
+      ]
+    }
+  };
+
+  const expectedHighlightedValues = [
+    {
+      fieldName: 'languages',
+      value: 'English',
+      path: ['featured', 'languages'],
+      matchedSubstrings: []
+    },
+    {
+      fieldName: 'languages',
+      value: 'Spanish',
+      path: ['featured', 'languages'],
+      matchedSubstrings: [
+        {
+          offset: 0,
+          length: 7
+        }
+      ]
+    }
+  ];
+
+  const actualHighlightedValues = HighlightedValueFactory.create(liveApiData);
+  expect(actualHighlightedValues).toMatchObject(expectedHighlightedValues);
+});

--- a/tests/transformers/HighlightedValueFactory.ts
+++ b/tests/transformers/HighlightedValueFactory.ts
@@ -131,38 +131,67 @@ it('Highlighted fields with arrays', () => {
   expect(actualHighlightedValues).toMatchObject(expectedHighlightedValues);
 });
 
-it('Highlighted fields with arbitrarily nested arrays', () => {
+it('Highlighted fields with arbitrarily placed arrays', () => {
   const liveApiData = {
     featured: {
-      languages: [
+      pie: [
         {
-          superDuper: [
+          value: 'apple',
+          matchedSubstrings: [
             {
-              value: 'super',
-              matchedSubstrings: []
-            },
-            {
-              value: 'deeduper',
-              matchedSubstrings: []
+              offset: 0,
+              length: 7
             }
-          ],
+          ]
         },
         {
-          reallyAwesome: {
-            value: 'Spanish',
-            matchedSubstrings: [
-              {
-                offset: 0,
-                length: 7
-              }
-            ]
-          }
+          value: 'cherry',
+          matchedSubstrings: [
+            {
+              offset: 1,
+              length: 2
+            }
+          ]
         }
-      ]
+      ],
+      languages: {
+        superDuper: [
+          {
+            value: 'super',
+            matchedSubstrings: []
+          },
+          {
+            value: 'deeduper',
+            matchedSubstrings: []
+          }
+        ],
+      }
     }
   };
 
   const expectedHighlightedValues = [
+    {
+      fieldName: 'pie',
+      value: 'apple',
+      path: ['featured', 'pie'],
+      matchedSubstrings: [
+        {
+          offset: 0,
+          length: 7
+        }
+      ]
+    },
+    {
+      fieldName: 'pie',
+      value: 'cherry',
+      path: ['featured', 'pie'],
+      matchedSubstrings: [
+        {
+          offset: 1,
+          length: 2
+        }
+      ]
+    },
     {
       fieldName: 'superDuper',
       value: 'super',
@@ -174,17 +203,6 @@ it('Highlighted fields with arbitrarily nested arrays', () => {
       value: 'deeduper',
       path: ['featured', 'languages', 'superDuper'],
       matchedSubstrings: []
-    },
-    {
-      fieldName: 'reallyAwesome',
-      value: 'Spanish',
-      path: ['featured', 'languages', 'reallyAwesome'],
-      matchedSubstrings: [
-        {
-          offset: 0,
-          length: 7
-        }
-      ]
     }
   ];
   const actualHighlightedValues = HighlightedValueFactory.create(liveApiData);


### PR DESCRIPTION
This commit adds support for highlighted fields that contain
array data. Previously, we would incorrectly use the array index as the fieldName.

J=SLAP-1194
TEST=auto,manual

hook up local SDK to my local core and see correct highlighted fields for
mt sinai, see highlighted fields being parsed correctly