### PR TITLE
Update ResultFactory data mappings

### DIFF
--- a/src/transformers/searchservice/ResultsFactory.ts
+++ b/src/transformers/searchservice/ResultsFactory.ts
@@ -12,34 +12,31 @@ export class ResultsFactory {
     }
 
     return results.map((result: any, index: number) => {
-      result = {
-        ...result,
-        index: index + 1
-      };
+      const resultIndex = index + 1;
 
       switch (source) {
         case Source.KnowledgeManager:
-          return this.fromKnowledgeManager(result);
+          return this.fromKnowledgeManager(result, resultIndex);
         case Source.Google:
-          return this.fromGoogleCustomSearchEngine(result);
+          return this.fromGoogleCustomSearchEngine(result, resultIndex);
         case Source.Bing:
-          return this.fromBingCustomSearchEngine(result);
+          return this.fromBingCustomSearchEngine(result, resultIndex);
         case Source.Zendesk:
-          return this.fromZendeskSearchEngine(result);
+          return this.fromZendeskSearchEngine(result, resultIndex);
         case Source.Algolia:
-          return this.fromAlgoliaSearchEngine(result);
+          return this.fromAlgoliaSearchEngine(result, resultIndex);
         default:
-          return this.fromGeneric(result);
+          return this.fromGeneric(result, resultIndex);
       }
     });
   }
 
-  private static fromKnowledgeManager(result: any): Result {
-    const rawData = result.data ?? {};
+  private static fromKnowledgeManager(result: any, index: number): Result {
+    const rawData = result.data ?? result;
     return {
       rawData: rawData,
       source: Source.KnowledgeManager,
-      index: result.index,
+      index: index,
       name: rawData.name,
       description: rawData.description,
       link: rawData.website,
@@ -51,58 +48,63 @@ export class ResultsFactory {
     };
   }
 
-  private static fromGoogleCustomSearchEngine(result: any): Result {
+  private static fromGoogleCustomSearchEngine(result: any, index: number): Result {
+    const rawData = result.data ?? result;
     return {
-      rawData: result,
+      rawData: rawData,
       source: Source.Google,
-      index: result.index,
-      name: result.htmlTitle.replace(/(<([^>]+)>)/ig, ''),
-      description: result.htmlSnippet,
-      link: result.link
+      index: index,
+      name: rawData.htmlTitle.replace(/(<([^>]+)>)/ig, ''),
+      description: rawData.htmlSnippet,
+      link: rawData.link
     };
   }
 
-  private static fromBingCustomSearchEngine(result: any): Result {
+  private static fromBingCustomSearchEngine(result: any, index: number): Result {
+    const rawData = result.data ?? result;
     return {
-      rawData: result,
+      rawData: rawData,
       source: Source.Bing,
-      index: result.index,
-      name: result.name,
-      description: result.snippet,
-      link: result.url
+      index: index,
+      name: rawData.name,
+      description: rawData.snippet,
+      link: rawData.url
     };
   }
 
-  private static fromZendeskSearchEngine(result: any): Result {
+  private static fromZendeskSearchEngine(result: any, index: number): Result {
+    const rawData = result.data ?? result;
     return {
-      rawData: result,
+      rawData: rawData,
       source: Source.Zendesk,
-      index: result.index,
-      name: result.title,
-      description: result.snippet,
-      link: result.html_url
+      index: index,
+      name: rawData.title,
+      description: rawData.snippet,
+      link: rawData.html_url
     };
   }
 
-  private static fromAlgoliaSearchEngine(result: any): Result {
+  private static fromAlgoliaSearchEngine(result: any, index: number): Result {
+    const rawData = result.data ?? result;
     return {
-      rawData: result,
+      rawData: rawData,
       source: Source.Algolia,
-      index: result.index,
-      name: result.name,
-      id: result.objectID
+      index: index,
+      name: rawData.name,
+      id: rawData.objectID
     };
   }
 
-  private static fromGeneric(result: any): Result {
+  private static fromGeneric(result: any, index: number): Result {
+    const rawData = result.data ?? result;
     return {
-      rawData: result,
+      rawData: rawData,
       source: Source.Generic,
-      index: result.index,
-      name: result.name,
-      description: result.description, // Do we want to truncate this like in the SDK?
-      link: result.website,
-      id: result.id,
+      index: index,
+      name: rawData.name,
+      description: rawData.description, // Do we want to truncate this like in the SDK?
+      link: rawData.website,
+      id: rawData.id
     };
   }
 

--- a/tests/transformers/searchservice/ResultsFactory.ts
+++ b/tests/transformers/searchservice/ResultsFactory.ts
@@ -1,0 +1,187 @@
+import { ResultsFactory } from '../../../src/transformers/searchservice/ResultsFactory';
+import { Source } from '../../../src/models/searchservice/response/Source';
+
+it('properly transforms Knowledge Graph results', () => {
+  const kgData = [{
+      data: {
+        id: 'Employee-2116',
+        type: 'ce_person',
+        website: 'http://www.test.com',
+        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+        name: 'Bob Smith',
+        firstName: 'Bob',
+        lastName: 'Smith',
+      },
+      highlightedFields: {},
+      distance: 36032,
+      distanceFromFilter: 3821
+    }
+  ];
+  const expectedResults = [{
+    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    distance: 36032,
+    distanceFromFilter: 3821,
+    entityType: 'ce_person',
+    highlightedValues: [],
+    id: 'Employee-2116',
+    index: 1,
+    link: 'http://www.test.com',
+    name: 'Bob Smith',
+    rawData: {
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+      firstName: 'Bob',
+      id: 'Employee-2116',
+      lastName: 'Smith',
+      name: 'Bob Smith',
+      type: 'ce_person',
+      website: 'http://www.test.com',
+    },
+    source: 'KNOWLEDGE_MANAGER',
+  }];
+
+  const actualResults = ResultsFactory.create(kgData, Source.KnowledgeManager);
+  expect(expectedResults).toMatchObject(actualResults);
+});
+
+it('properly transforms Zendesk results', () => {
+  const zendeskData = [{
+    html_url: 'https://help.yext.com/',
+    id: 8273729837,
+    snippet: 'Enter the Preview link into the text box.',
+    title: 'Add Custom Schema.org Markup',
+  }];
+
+  const expectedResults = [{
+    description: 'Enter the Preview link into the text box.',
+    index: 1,
+    link: 'https://help.yext.com/',
+    name: 'Add Custom Schema.org Markup',
+      rawData: {
+       html_url: 'https://help.yext.com/',
+       id: 8273729837,
+       snippet: 'Enter the Preview link into the text box.',
+       title: 'Add Custom Schema.org Markup',
+     },
+     source: 'ZENDESK',
+  }];
+
+  const actualResults = ResultsFactory.create(zendeskData, Source.Zendesk);
+  expect(expectedResults).toMatchObject(actualResults);
+});
+
+it('properly transforms Algolia results', () => {
+  const algoliaData = [{
+    location: 'Atlanta',
+    logoUrl: 'Hawks_Atlanta.gif',
+    name: 'Hawks',
+    objectID: '49688642',
+    score: 595.5714285714286
+  }];
+
+  const expectedResults = [{
+    id: '49688642',
+    index: 1,
+    name: 'Hawks',
+    rawData: {
+      location: 'Atlanta',
+      logoUrl: 'Hawks_Atlanta.gif',
+      name: 'Hawks',
+      objectID: '49688642',
+      score: 595.5714285714286,
+    },
+    source: 'ALGOLIA',
+  }];
+
+  const actualResults = ResultsFactory.create(algoliaData, Source.Algolia);
+  expect(expectedResults).toMatchObject(actualResults);
+});
+
+it('properly transforms Google Custom Search results', () => {
+  const googleData = [{
+    displayLink: 'www.yext.com',
+    htmlSnippet: '<b>Yext</b> is improving the online search experiences',
+    htmlTitle: 'Yext',
+    link: 'https://www.yext.com/'
+  }];
+
+  const expectedResults = [{
+    description: '<b>Yext</b> is improving the online search experiences',
+    index: 1,
+    link: 'https://www.yext.com/',
+    name: 'Yext',
+    rawData: {
+      displayLink: 'www.yext.com',
+      htmlSnippet: '<b>Yext</b> is improving the online search experiences',
+      htmlTitle: 'Yext',
+      link: 'https://www.yext.com/',
+    },
+    source: 'GOOGLE_CSE',
+  }];
+
+  const actualResults = ResultsFactory.create(googleData, Source.Google);
+  expect(expectedResults).toMatchObject(actualResults);
+});
+
+it('properly transforms Bing search results', () => {
+  const bingData = [{
+    displayUrl: 'www.yext.com/support',
+    name: 'Yext support',
+    snippet: 'Get help from Yext',
+    url: 'http://www.yext.com/support'
+  }];
+
+  const expectedResults = [{
+    description: 'Get help from Yext',
+    index: 1,
+    link: 'http://www.yext.com/support',
+    name: 'Yext support',
+    rawData: {
+      displayUrl: 'www.yext.com/support',
+      name: 'Yext support',
+      snippet: 'Get help from Yext',
+      url: 'http://www.yext.com/support',
+    },
+    source: 'BING_CSE',
+  }];
+
+  const actualResults = ResultsFactory.create(bingData, Source.Bing);
+  expect(expectedResults).toMatchObject(actualResults);
+});
+
+it('properly transforms generic backend results', () => {
+  const genericData = [{
+    data: {
+      answer: 'You should still self\-quarantine for 14 days since your last exposure.',
+      c_organization: 'CDC',
+      id: 'iwasaroundsomeonewhohascovid19andmycovid19testcame',
+      keywords: ['covid', 'COVID-19', 'Coronavirus'],
+      website: 'https://www.cdc.gov/coronavirus/2019-ncov/faq.html',
+      name: 'Do I still need to quarantine for 14 days?',
+      type: 'faq',
+      description: 'COVID question'
+    },
+    highlightedFields: {}
+  }];
+
+  const expectedResults = [{
+    description: 'COVID question',
+    id: 'iwasaroundsomeonewhohascovid19andmycovid19testcame',
+    index: 1,
+    link: 'https://www.cdc.gov/coronavirus/2019-ncov/faq.html',
+    name: 'Do I still need to quarantine for 14 days?',
+    rawData: {
+      answer: 'You should still self-quarantine for 14 days since your last exposure.',
+      c_organization: 'CDC',
+      id: 'iwasaroundsomeonewhohascovid19andmycovid19testcame',
+      keywords: ['covid', 'COVID-19', 'Coronavirus'],
+      website: 'https://www.cdc.gov/coronavirus/2019-ncov/faq.html',
+      name: 'Do I still need to quarantine for 14 days?',
+      type: 'faq',
+      description: 'COVID question'
+    },
+    source: 'GENERIC',
+  }];
+
+  const actualResults = ResultsFactory.create(genericData, Source.Generic);
+  expect(expectedResults).toMatchObject(actualResults);
+});


### PR DESCRIPTION
Update data mappings for the results in the result factory

This PR makes is such that the rawData field is first the result data
field, with a fallback to the result itself. This matches the fallback
behavior of the Answers Search UI v1.7.

J=SLAP-1184
TEST=manual, unit

Use the core test site and the theme test site to confirm that the KG and Google search backends still work. Test the CUSTOM_SEARCHER backend on a client's site and test that the profile passed to the card is correct. Add unit tests.