### PR TITLE
add Coveralls code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,3 @@
-
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,10 @@
 
 name: Code Coverage
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore: dev/*
+  pull_request:
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,28 @@
+
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Code Coverage
+
+on: [push, pull_request]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npx jest --coverage
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# This workflow will run our tests, generate an lcov code coverage file,
+# and send that coverage to Coveralls 
 
 name: Code Coverage
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 jobs:
-  coverage:
+  Coveralls:
     runs-on: ubuntu-latest
 
     strategy:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
   <a href="./LICENSE">
     <img src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg" alt="License"/>
   </a>
+  <a href='https://coveralls.io/github/yext/answers-core?branch=master'>
+    <img src='https://coveralls.io/repos/github/yext/answers-core/badge.svg?branch=master' alt='Coverage Status' />
+  </a>
 </div>
 <br>
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "jest": {
     "bail": 0,
-    "collectCoverageFrom": ["src/**/*.ts"],
+    "collectCoverageFrom": ["src/**"],
     "verbose": true,
     "moduleFileExtensions": [
       "js",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "jest": {
     "bail": 0,
+    "collectCoverageFrom": ["src/**/*.ts"],
     "verbose": true,
     "moduleFileExtensions": [
       "js",


### PR DESCRIPTION
Adds a Coveralls github workflow, also adds a coverage badge
to the readme. I tried looking online for a way to make the coverage
badge reflect the current branch, instead of always master,
but it sounds like there's no way to do that with a static readme.

J=SLAP-873
TEST=auto

we have a coveralls check now (see below) that displays the code coverage percent, wow!
clicking into it links to the coverage for the build, double wow!