### PR TITLE
add AnswersConfig.additionalQueryParams? property

### DIFF
--- a/etc/answers-core.api.md
+++ b/etc/answers-core.api.md
@@ -6,6 +6,10 @@
 
 // @public
 export interface AnswersConfig {
+    // @internal
+    additionalQueryParams?: {
+        [key: string]: string | number | boolean;
+    };
     apiKey: string;
     // @internal
     endpoints?: Endpoints;

--- a/etc/answers-core.api.md
+++ b/etc/answers-core.api.md
@@ -6,7 +6,7 @@
 
 // @public
 export interface AnswersConfig {
-    // @internal
+    // @alpha
     additionalQueryParams?: {
         [key: string]: string | number | boolean;
     };

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
   },
   "jest": {
     "bail": 0,
-    "collectCoverageFrom": ["src/**"],
+    "collectCoverageFrom": [
+      "src/**"
+    ],
     "verbose": true,
     "moduleFileExtensions": [
       "js",

--- a/src/infra/AutocompleteServiceImpl.ts
+++ b/src/infra/AutocompleteServiceImpl.ts
@@ -69,7 +69,8 @@ export class AutocompleteServiceImpl implements AutocompleteService {
       v: defaultApiVersion,
       version: this.config.experienceVersion,
       locale: this.config.locale,
-      sessionTrackingEnabled: request.sessionTrackingEnabled
+      sessionTrackingEnabled: request.sessionTrackingEnabled,
+      ...this.config?.additionalQueryParams
     };
 
     const response = await this.httpService.get<ApiResponse>(
@@ -99,7 +100,8 @@ export class AutocompleteServiceImpl implements AutocompleteService {
       version: this.config.experienceVersion,
       locale: this.config.locale,
       verticalKey: request.verticalKey,
-      sessionTrackingEnabled: request.sessionTrackingEnabled
+      sessionTrackingEnabled: request.sessionTrackingEnabled,
+      ...this.config?.additionalQueryParams
     };
 
     const response = await this.httpService.get<ApiResponse>(
@@ -134,7 +136,8 @@ export class AutocompleteServiceImpl implements AutocompleteService {
       locale: this.config.locale,
       search_parameters: JSON.stringify(searchParams),
       verticalKey: request.verticalKey,
-      sessionTrackingEnabled: request.sessionTrackingEnabled
+      sessionTrackingEnabled: request.sessionTrackingEnabled,
+      ...this.config?.additionalQueryParams
     };
 
     const response = await this.httpService.get<ApiResponse>(

--- a/src/infra/QuestionSubmissionServiceImpl.ts
+++ b/src/infra/QuestionSubmissionServiceImpl.ts
@@ -34,7 +34,8 @@ export class QuestionSubmissionServiceImpl implements QuestionSubmissionService 
     const queryParams = {
       v: defaultApiVersion,
       api_key: this.config.apiKey,
-      sessionTrackingEnabled: request.sessionTrackingEnabled
+      sessionTrackingEnabled: request.sessionTrackingEnabled,
+      ...this.config?.additionalQueryParams
     };
 
     const body = {

--- a/src/infra/SearchServiceImpl.ts
+++ b/src/infra/SearchServiceImpl.ts
@@ -109,7 +109,8 @@ export class SearchServiceImpl implements SearchService {
       queryTrigger: request.queryTrigger,
       context: JSON.stringify(request.context || undefined),
       referrerPageUrl: request.referrerPageUrl,
-      source: request.querySource || QuerySource.Standard
+      source: request.querySource || QuerySource.Standard,
+      ...this.config?.additionalQueryParams
     };
 
     const response =
@@ -148,7 +149,8 @@ export class SearchServiceImpl implements SearchService {
       referrerPageUrl: request.referrerPageUrl,
       source: request.querySource || QuerySource.Standard,
       locationRadius: request.locationRadius?.toString(),
-      queryId: request.queryId
+      queryId: request.queryId,
+      ...this.config?.additionalQueryParams
     };
 
     const response =

--- a/src/models/core/AnswersConfig.ts
+++ b/src/models/core/AnswersConfig.ts
@@ -27,5 +27,13 @@ export interface AnswersConfig {
    *
    * @internal
    */
-  endpoints?: Endpoints
+  endpoints?: Endpoints,
+  /**
+   * Additional query params added on to every request.
+   *
+   * @internal
+   */
+  additionalQueryParams?: {
+    [key: string]: string | number | boolean
+  }
 }

--- a/src/models/core/AnswersConfig.ts
+++ b/src/models/core/AnswersConfig.ts
@@ -31,7 +31,7 @@ export interface AnswersConfig {
   /**
    * Additional query params added on to every request.
    *
-   * @internal
+   * @alpha
    */
   additionalQueryParams?: {
     [key: string]: string | number | boolean

--- a/tests/infra/AutoCompleteServiceImpl.ts
+++ b/tests/infra/AutoCompleteServiceImpl.ts
@@ -129,21 +129,16 @@ describe('additionalQueryParams are passed through', () => {
       jsLibVersion: 'LIB_VERSION'
     }
   };
-  const mockHttpService = new HttpServiceMock();
-  const apiResponseValidator = new ApiResponseValidator();
+  let mockHttpService, apiResponseValidator;
+  beforeEach(() => {
+    mockHttpService = new HttpServiceMock();
+    apiResponseValidator = new ApiResponseValidator();
+  });
 
   it('Universal Autocomplete', async () => {
     mockHttpService.get.mockResolvedValue(mockAutocompleteResponse);
     const request: UniversalAutocompleteRequest = {
       input: ''
-    };
-    const expectedQueryParams = {
-      input: '',
-      experienceKey: 'testExperienceKey',
-      api_key: 'testApiKey',
-      v: 20190101,
-      locale: 'en',
-      jsLibVersion: 'LIB_VERSION'
     };
     const autocompleteService = new AutocompleteServiceImpl(
       config,
@@ -151,7 +146,10 @@ describe('additionalQueryParams are passed through', () => {
       apiResponseValidator
     );
     await autocompleteService.universalAutocomplete(request);
-    expect(mockHttpService.get).toHaveBeenCalledWith(expectedUniversalUrl, expectedQueryParams);
+    expect(mockHttpService.get).toHaveBeenCalledTimes(1);
+    expect(mockHttpService.get.mock.calls[0][1]).toEqual(expect.objectContaining({
+      jsLibVersion: 'LIB_VERSION'
+    }));
   });
 
   it('Vertical Autocomplete', async () => {
@@ -160,53 +158,25 @@ describe('additionalQueryParams are passed through', () => {
       input: 'salesforce',
       verticalKey: 'verticalKey'
     };
-    const expectedQueryParams = {
-      input: 'salesforce',
-      experienceKey: 'testExperienceKey',
-      api_key: 'testApiKey',
-      v: 20190101,
-      locale: 'en',
-      verticalKey: 'verticalKey',
-      jsLibVersion: 'LIB_VERSION'
-    };
     const autocompleteService = new AutocompleteServiceImpl(
       config,
       mockHttpService as HttpService,
       apiResponseValidator
     );
     await autocompleteService.verticalAutocomplete(request);
-    expect(mockHttpService.get).toHaveBeenCalledWith(expectedVerticalUrl, expectedQueryParams);
+    expect(mockHttpService.get).toHaveBeenCalledTimes(1);
+    expect(mockHttpService.get.mock.calls[0][1]).toEqual(expect.objectContaining({
+      jsLibVersion: 'LIB_VERSION'
+    }));
   });
 
   it('FilterSearch', async () => {
     mockHttpService.get.mockResolvedValue(mockAutocompleteResponseWithSections);
-    const convertedSearchParams = {
-      sectioned: false,
-      fields: [{
-        fieldId: 'field',
-        entityTypeId: 'location',
-        shouldFetchEntities: false
-      }]
-    };
     const request: FilterSearchRequest = {
       input: 'salesforce',
       verticalKey: 'verticalKey',
       sectioned: false,
-      fields: [{
-        fieldApiName: 'field',
-        entityType: 'location',
-        fetchEntities: false
-      }]
-    };
-    const expectedQueryParams = {
-      input: 'salesforce',
-      experienceKey: 'testExperienceKey',
-      api_key: 'testApiKey',
-      v: 20190101,
-      locale: 'en',
-      verticalKey: 'verticalKey',
-      search_parameters: JSON.stringify(convertedSearchParams),
-      jsLibVersion: 'LIB_VERSION'
+      fields: []
     };
     const autocompleteService = new AutocompleteServiceImpl(
       config,
@@ -214,6 +184,9 @@ describe('additionalQueryParams are passed through', () => {
       apiResponseValidator
     );
     await autocompleteService.filterSearch(request);
-    expect(mockHttpService.get).toHaveBeenCalledWith(expectedFilterUrl, expectedQueryParams);
+    expect(mockHttpService.get).toHaveBeenCalledTimes(1);
+    expect(mockHttpService.get.mock.calls[0][1]).toEqual(expect.objectContaining({
+      jsLibVersion: 'LIB_VERSION'
+    }));
   });
 });

--- a/tests/infra/AutoCompleteServiceImpl.ts
+++ b/tests/infra/AutoCompleteServiceImpl.ts
@@ -12,19 +12,20 @@ import mockAutocompleteResponseWithSections from '../fixtures/autocompleterespon
 import { defaultEndpoints } from '../../src/constants';
 import { ApiResponseValidator } from '../../src/validation/ApiResponseValidator';
 
+const expectedVerticalUrl = defaultEndpoints.verticalAutocomplete;
+const expectedUniversalUrl = defaultEndpoints.universalAutocomplete;
+const expectedFilterUrl = defaultEndpoints.filterSearch;
+
 describe('AutocompleteService', () => {
   const config: AnswersConfig = {
     apiKey: 'testApiKey',
     experienceKey: 'testExperienceKey',
     locale: 'en',
   };
-
   const mockHttpService = new HttpServiceMock();
-
   const apiResponseValidator = new ApiResponseValidator();
 
   describe('Universal Autocomplete', () => {
-    const expectedUniversalUrl = defaultEndpoints.universalAutocomplete;
     it('query params are correct', async () => {
       mockHttpService.get.mockResolvedValue(mockAutocompleteResponse);
       const request: UniversalAutocompleteRequest = {
@@ -50,7 +51,6 @@ describe('AutocompleteService', () => {
   });
 
   describe('Vertical Autocomplete', () => {
-    const expectedVerticalUrl = defaultEndpoints.verticalAutocomplete;
     it('query params are correct', async () => {
       mockHttpService.get.mockResolvedValue(mockAutocompleteResponse);
       const request: VerticalAutocompleteRequest = {
@@ -78,7 +78,6 @@ describe('AutocompleteService', () => {
   });
 
   describe('FilterSearch', () => {
-    const expectedFilterUrl = defaultEndpoints.filterSearch;
     it('query params are correct', async () => {
       mockHttpService.get.mockResolvedValue(mockAutocompleteResponseWithSections);
       const convertedSearchParams = {
@@ -118,5 +117,103 @@ describe('AutocompleteService', () => {
       await autocompleteService.filterSearch(request);
       expect(mockHttpService.get).toHaveBeenCalledWith(expectedFilterUrl, expectedQueryParams);
     });
+  });
+});
+
+describe('additionalQueryParams are passed through', () => {
+  const config: AnswersConfig = {
+    apiKey: 'testApiKey',
+    experienceKey: 'testExperienceKey',
+    locale: 'en',
+    additionalQueryParams: {
+      jsLibVersion: 'LIB_VERSION'
+    }
+  };
+  const mockHttpService = new HttpServiceMock();
+  const apiResponseValidator = new ApiResponseValidator();
+
+  it('Universal Autocomplete', async () => {
+    mockHttpService.get.mockResolvedValue(mockAutocompleteResponse);
+    const request: UniversalAutocompleteRequest = {
+      input: ''
+    };
+    const expectedQueryParams = {
+      input: '',
+      experienceKey: 'testExperienceKey',
+      api_key: 'testApiKey',
+      v: 20190101,
+      locale: 'en',
+      jsLibVersion: 'LIB_VERSION'
+    };
+    const autocompleteService = new AutocompleteServiceImpl(
+      config,
+      mockHttpService as HttpService,
+      apiResponseValidator
+    );
+    await autocompleteService.universalAutocomplete(request);
+    expect(mockHttpService.get).toHaveBeenCalledWith(expectedUniversalUrl, expectedQueryParams);
+  });
+
+  it('Vertical Autocomplete', async () => {
+    mockHttpService.get.mockResolvedValue(mockAutocompleteResponse);
+    const request: VerticalAutocompleteRequest = {
+      input: 'salesforce',
+      verticalKey: 'verticalKey'
+    };
+    const expectedQueryParams = {
+      input: 'salesforce',
+      experienceKey: 'testExperienceKey',
+      api_key: 'testApiKey',
+      v: 20190101,
+      locale: 'en',
+      verticalKey: 'verticalKey',
+      jsLibVersion: 'LIB_VERSION'
+    };
+    const autocompleteService = new AutocompleteServiceImpl(
+      config,
+      mockHttpService as HttpService,
+      apiResponseValidator
+    );
+    await autocompleteService.verticalAutocomplete(request);
+    expect(mockHttpService.get).toHaveBeenCalledWith(expectedVerticalUrl, expectedQueryParams);
+  });
+
+  it('FilterSearch', async () => {
+    mockHttpService.get.mockResolvedValue(mockAutocompleteResponseWithSections);
+    const convertedSearchParams = {
+      sectioned: false,
+      fields: [{
+        fieldId: 'field',
+        entityTypeId: 'location',
+        shouldFetchEntities: false
+      }]
+    };
+    const request: FilterSearchRequest = {
+      input: 'salesforce',
+      verticalKey: 'verticalKey',
+      sectioned: false,
+      fields: [{
+        fieldApiName: 'field',
+        entityType: 'location',
+        fetchEntities: false
+      }]
+    };
+    const expectedQueryParams = {
+      input: 'salesforce',
+      experienceKey: 'testExperienceKey',
+      api_key: 'testApiKey',
+      v: 20190101,
+      locale: 'en',
+      verticalKey: 'verticalKey',
+      search_parameters: JSON.stringify(convertedSearchParams),
+      jsLibVersion: 'LIB_VERSION'
+    };
+    const autocompleteService = new AutocompleteServiceImpl(
+      config,
+      mockHttpService as HttpService,
+      apiResponseValidator
+    );
+    await autocompleteService.filterSearch(request);
+    expect(mockHttpService.get).toHaveBeenCalledWith(expectedFilterUrl, expectedQueryParams);
   });
 });

--- a/tests/infra/AutoCompleteServiceImpl.ts
+++ b/tests/infra/AutoCompleteServiceImpl.ts
@@ -12,10 +12,6 @@ import mockAutocompleteResponseWithSections from '../fixtures/autocompleterespon
 import { defaultEndpoints } from '../../src/constants';
 import { ApiResponseValidator } from '../../src/validation/ApiResponseValidator';
 
-const expectedVerticalUrl = defaultEndpoints.verticalAutocomplete;
-const expectedUniversalUrl = defaultEndpoints.universalAutocomplete;
-const expectedFilterUrl = defaultEndpoints.filterSearch;
-
 describe('AutocompleteService', () => {
   const config: AnswersConfig = {
     apiKey: 'testApiKey',
@@ -26,6 +22,7 @@ describe('AutocompleteService', () => {
   const apiResponseValidator = new ApiResponseValidator();
 
   describe('Universal Autocomplete', () => {
+    const expectedUniversalUrl = defaultEndpoints.universalAutocomplete;
     it('query params are correct', async () => {
       mockHttpService.get.mockResolvedValue(mockAutocompleteResponse);
       const request: UniversalAutocompleteRequest = {
@@ -51,6 +48,7 @@ describe('AutocompleteService', () => {
   });
 
   describe('Vertical Autocomplete', () => {
+    const expectedVerticalUrl = defaultEndpoints.verticalAutocomplete;
     it('query params are correct', async () => {
       mockHttpService.get.mockResolvedValue(mockAutocompleteResponse);
       const request: VerticalAutocompleteRequest = {
@@ -78,6 +76,7 @@ describe('AutocompleteService', () => {
   });
 
   describe('FilterSearch', () => {
+    const expectedFilterUrl = defaultEndpoints.filterSearch;
     it('query params are correct', async () => {
       mockHttpService.get.mockResolvedValue(mockAutocompleteResponseWithSections);
       const convertedSearchParams = {
@@ -129,22 +128,22 @@ describe('additionalQueryParams are passed through', () => {
       jsLibVersion: 'LIB_VERSION'
     }
   };
-  let mockHttpService, apiResponseValidator;
+  let mockHttpService, apiResponseValidator, autocompleteService;
   beforeEach(() => {
     mockHttpService = new HttpServiceMock();
-    apiResponseValidator = new ApiResponseValidator();
-  });
-
-  it('Universal Autocomplete', async () => {
     mockHttpService.get.mockResolvedValue(mockAutocompleteResponse);
-    const request: UniversalAutocompleteRequest = {
-      input: ''
-    };
-    const autocompleteService = new AutocompleteServiceImpl(
+    apiResponseValidator = new ApiResponseValidator();
+    autocompleteService = new AutocompleteServiceImpl(
       config,
       mockHttpService as HttpService,
       apiResponseValidator
     );
+  });
+
+  it('Universal Autocomplete', async () => {
+    const request: UniversalAutocompleteRequest = {
+      input: 'salesforce'
+    };
     await autocompleteService.universalAutocomplete(request);
     expect(mockHttpService.get).toHaveBeenCalledTimes(1);
     expect(mockHttpService.get.mock.calls[0][1]).toEqual(expect.objectContaining({
@@ -153,16 +152,10 @@ describe('additionalQueryParams are passed through', () => {
   });
 
   it('Vertical Autocomplete', async () => {
-    mockHttpService.get.mockResolvedValue(mockAutocompleteResponse);
     const request: VerticalAutocompleteRequest = {
       input: 'salesforce',
       verticalKey: 'verticalKey'
     };
-    const autocompleteService = new AutocompleteServiceImpl(
-      config,
-      mockHttpService as HttpService,
-      apiResponseValidator
-    );
     await autocompleteService.verticalAutocomplete(request);
     expect(mockHttpService.get).toHaveBeenCalledTimes(1);
     expect(mockHttpService.get.mock.calls[0][1]).toEqual(expect.objectContaining({
@@ -171,18 +164,12 @@ describe('additionalQueryParams are passed through', () => {
   });
 
   it('FilterSearch', async () => {
-    mockHttpService.get.mockResolvedValue(mockAutocompleteResponseWithSections);
     const request: FilterSearchRequest = {
       input: 'salesforce',
       verticalKey: 'verticalKey',
       sectioned: false,
       fields: []
     };
-    const autocompleteService = new AutocompleteServiceImpl(
-      config,
-      mockHttpService as HttpService,
-      apiResponseValidator
-    );
     await autocompleteService.filterSearch(request);
     expect(mockHttpService.get).toHaveBeenCalledTimes(1);
     expect(mockHttpService.get.mock.calls[0][1]).toEqual(expect.objectContaining({

--- a/tests/infra/QuestionSubmissionServiceImpl.ts
+++ b/tests/infra/QuestionSubmissionServiceImpl.ts
@@ -107,3 +107,24 @@ describe('Question submission', () => {
     });
   });
 });
+
+it('additionalQueryParams are passed through', async () => {
+  const coreConfig = {
+    ...baseCoreConfig,
+    additionalQueryParams: {
+      jsLibVersion: 'LIB_VERSION'
+    }
+  };
+  const qaService = new QuestionSubmissionServiceImpl(coreConfig, mockHttp as HttpService, apiResponseValidator);
+  await qaService.submitQuestion(qaRequest);
+  const mockCalls = mockHttp.post.mock.calls;
+  const actualHttpParams = mockCalls[mockCalls.length - 1];
+  const expectedQueryParams = {
+    api_key: 'anApiKey',
+    sessionTrackingEnabled: true,
+    v: 20190101,
+    jsLibVersion: 'LIB_VERSION'
+  };
+  const actualQueryParams = actualHttpParams[1];
+  expect(expectedQueryParams).toEqual(actualQueryParams);
+});

--- a/tests/infra/QuestionSubmissionServiceImpl.ts
+++ b/tests/infra/QuestionSubmissionServiceImpl.ts
@@ -19,23 +19,19 @@ const qaRequest = {
   sessionTrackingEnabled: true
 };
 
-const mockHttp = new HttpServiceMock();
-mockHttp.post.mockResolvedValue({
-  meta: {
-    uuid: 'aUUID'
-  },
-  response: {}
-});
-
 const apiResponseValidator = new ApiResponseValidator();
 
 describe('Question submission', () => {
-  let qaService;
-  let response;
-  let mockCalls;
-  let actualHttpParams;
+  let mockHttp, qaService, response, mockCalls, actualHttpParams;
 
   beforeAll(async () => {
+    mockHttp = new HttpServiceMock();
+    mockHttp.post.mockResolvedValue({
+      meta: {
+        uuid: 'aUUID'
+      },
+      response: {}
+    });
     qaService = new QuestionSubmissionServiceImpl(baseCoreConfig, mockHttp as HttpService, apiResponseValidator);
     response = await qaService.submitQuestion(qaRequest);
     mockCalls = mockHttp.post.mock.calls;
@@ -115,16 +111,18 @@ it('additionalQueryParams are passed through', async () => {
       jsLibVersion: 'LIB_VERSION'
     }
   };
+  const mockHttp = new HttpServiceMock();
+  mockHttp.post.mockResolvedValue({
+    meta: {
+      uuid: 'aUUID'
+    },
+    response: {}
+  });
   const qaService = new QuestionSubmissionServiceImpl(coreConfig, mockHttp as HttpService, apiResponseValidator);
   await qaService.submitQuestion(qaRequest);
   const mockCalls = mockHttp.post.mock.calls;
-  const actualHttpParams = mockCalls[mockCalls.length - 1];
-  const expectedQueryParams = {
-    api_key: 'anApiKey',
-    sessionTrackingEnabled: true,
-    v: 20190101,
+  const actualQueryParams = mockCalls[0][1];
+  expect(actualQueryParams).toEqual(expect.objectContaining({
     jsLibVersion: 'LIB_VERSION'
-  };
-  const actualQueryParams = actualHttpParams[1];
-  expect(expectedQueryParams).toEqual(actualQueryParams);
+  }));
 });

--- a/tests/infra/SearchServiceImpl.ts
+++ b/tests/infra/SearchServiceImpl.ts
@@ -274,17 +274,11 @@ describe('additionalQueryParams are passed through', () => {
     const request: UniversalSearchRequest = {
       query: 'testQuery'
     };
-    const expectedQueryParams = {
-      api_key: 'testApiKey',
-      experienceKey: 'testExperienceKey',
-      input: 'testQuery',
-      locale: 'en',
-      v: 20190101,
-      source: 'STANDARD',
-      jsLibVersion: 'LIB_VERSION'
-    };
     await searchService.universalSearch(request);
-    expect(mockHttpService.get).toHaveBeenCalledWith(expectedUniversalUrl, expectedQueryParams);
+    expect(mockHttpService.get).toHaveBeenCalledTimes(1);
+    expect(mockHttpService.get.mock.calls[0][1]).toEqual(expect.objectContaining({
+      jsLibVersion: 'LIB_VERSION'
+    }));
   });
 
   it('verticalSearch', async () => {
@@ -292,18 +286,11 @@ describe('additionalQueryParams are passed through', () => {
       query: 'testQuery',
       verticalKey: 'verticalKey'
     };
-    const expectedQueryParams = {
-      api_key: 'testApiKey',
-      experienceKey: 'testExperienceKey',
-      verticalKey: 'verticalKey',
-      input: 'testQuery',
-      locale: 'en',
-      v: 20190101,
-      source: 'STANDARD',
-      sortBys: '[]',
-      jsLibVersion: 'LIB_VERSION'
-    };
+
     await searchService.verticalSearch(request);
-    expect(mockHttpService.get).toHaveBeenCalledWith(expectedVerticalUrl, expectedQueryParams);
+    expect(mockHttpService.get).toHaveBeenCalledTimes(1);
+    expect(mockHttpService.get.mock.calls[0][1]).toEqual(expect.objectContaining({
+      jsLibVersion: 'LIB_VERSION'
+    }));
   });
 });

--- a/tests/infra/SearchServiceImpl.ts
+++ b/tests/infra/SearchServiceImpl.ts
@@ -11,9 +11,6 @@ import { Matcher } from '../../src/models/searchservice/common/Matcher';
 import { Direction } from '../../src/models/searchservice/request/Direction';
 import { SortType } from '../../src/models/searchservice/request/SortType';
 
-const expectedVerticalUrl = 'https://liveapi.yext.com/v2/accounts/me/answers/vertical/query';
-const expectedUniversalUrl = 'https://liveapi.yext.com/v2/accounts/me/answers/query';
-
 describe('SearchService', () => {
   const configWithRequiredParams: AnswersConfig = {
     apiKey: 'testApiKey',
@@ -53,6 +50,8 @@ describe('SearchService', () => {
   });
 
   describe('Universal Search', () => {
+    const expectedUniversalUrl = 'https://liveapi.yext.com/v2/accounts/me/answers/query';
+
     it('Query params are correct when only required params are supplied', async () => {
       const requestWithRequiredParams: UniversalSearchRequest = {
         query: 'testQuery'
@@ -123,6 +122,8 @@ describe('SearchService', () => {
   });
 
   describe('Vertical Search', ()=> {
+    const expectedVerticalUrl = 'https://liveapi.yext.com/v2/accounts/me/answers/vertical/query';
+
     it('Query params are correct when only required params are supplied', async () => {
       const requestWithRequiredParams: VerticalSearchRequest = {
         query: 'testQuery',


### PR DESCRIPTION
This commit adds an additionalQueryParams prop to AnswersConfig.
These additional params will be passed as
query params to every single request made by answers-core.

Because this property is marked as alpha, it is not exported as part of the
AnswersConfig interface, and any typescript users of core will receive
a compilation error if they try to use this property. This property can
still be used in regular js usages of core. In a following PR, we will
add an untrimmed bundle.d.ts which will include alpha and internal
types.

J=SLAP-1320
T=405448
TEST=manual,auto

use local core in the SDK, see that jsLibVersion is passed in search, autocomplete,
and qa submission requests
also try in answers-core-testing