### PR TITLE
add internal bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ core.verticalSearch({
 ```
 
 ### Explanation of Builds
+
 - The ESM (ES6) build will be used automatically by module bundlers that support it (e.g. Webpack). It can be specified directly by importing `@yext/answers-core/lib/esm`
 - The CommonJS build will be used automatically by Node, but it can be specified directly by importing `@yext/answers-core/lib/commonjs`
 - The Legacy (UMD) bundle should be used for supporting IE11 out of the box. It is compiled to ES5 and it contains the necessary ponyfills for IE11. If your application already contains polyfills, we recommend bundling one of the other builds in order to prevent your application from including duplicate polyfills. This bundle can be specified by importing `@yext/answers-core/legacy`

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -195,7 +195,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/dist/<unscopedPackageName>.d.ts"
      */
-    "untrimmedFilePath": "",
+    "untrimmedFilePath": "<projectFolder>/dist/bundle-internal.d.ts",
 
     /**
      * Specifies the output path for a .d.ts rollup file to be generated with trimming for a "beta" release.

--- a/internal/package.json
+++ b/internal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "answers-core-legacy",
+  "name": "answers-core-internal",
   "main": "../lib/esm/index.js",
   "types": "../dist/bundle-internal.d.ts"
 }

--- a/internal/package.json
+++ b/internal/package.json
@@ -1,5 +1,6 @@
 {
   "name": "answers-core-internal",
-  "main": "../lib/esm/index.js",
+  "main": "./lib/commonjs/index.js",
+  "module": "./lib/esm/index.js",
   "types": "../dist/bundle-internal.d.ts"
 }

--- a/internal/package.json
+++ b/internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "answers-core-internal",
-  "main": "./lib/commonjs/index.js",
-  "module": "./lib/esm/index.js",
+  "main": "../lib/commonjs/index.js",
+  "module": "../lib/esm/index.js",
   "types": "../dist/bundle-internal.d.ts"
 }

--- a/internal/package.json
+++ b/internal/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "answers-core-legacy",
+  "main": "../lib/esm/index.js",
+  "types": "../dist/bundle-internal.d.ts"
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/bundle.d.ts",
   "files": [
     "dist",
+    "internal",
     "legacy",
     "lib"
   ],


### PR DESCRIPTION
The internal bundle lets TS users use internal
and alpha types. internal and alpha types are
still exported with the lib/esm and lib/commonjs
bundles, SLAP-1325 was made to address those
at a later date.

J=SLAP-1321
TEST=manual

test that I can use the internal bundle in the
core testing lib