### PR TITLE
Allow arbitrary string query sources

### DIFF
--- a/docs/answers-core.universalsearchrequest.md
+++ b/docs/answers-core.universalsearchrequest.md
@@ -20,7 +20,7 @@ export interface UniversalSearchRequest
 |  [limit?](./answers-core.universalsearchrequest.limit.md) | [UniversalLimit](./answers-core.universallimit.md) | <i>(Optional)</i> The maximum limit of results per vertical. Each limit can be set from 1-50, inclusive. |
 |  [location?](./answers-core.universalsearchrequest.location.md) | [LatLong](./answers-core.latlong.md) | <i>(Optional)</i> The latitude and longitude of the user making the request. Used to bias the results. |
 |  [query](./answers-core.universalsearchrequest.query.md) | string | The search query. |
-|  [querySource?](./answers-core.universalsearchrequest.querysource.md) | [QuerySource](./answers-core.querysource.md) | <i>(Optional)</i> The source of the search request. |
+|  [querySource?](./answers-core.universalsearchrequest.querysource.md) | [QuerySource](./answers-core.querysource.md) \| string | <i>(Optional)</i> The source of the search request. |
 |  [queryTrigger?](./answers-core.universalsearchrequest.querytrigger.md) | [QueryTrigger](./answers-core.querytrigger.md) | <i>(Optional)</i> Describes the ways a search can be executed besides user input. |
 |  [referrerPageUrl?](./answers-core.universalsearchrequest.referrerpageurl.md) | string | <i>(Optional)</i> The URl of the page which referred the user to the current page. |
 |  [sessionId?](./answers-core.universalsearchrequest.sessionid.md) | string | <i>(Optional)</i> Used to track session state when cookies are blocked. |

--- a/docs/answers-core.universalsearchrequest.querysource.md
+++ b/docs/answers-core.universalsearchrequest.querysource.md
@@ -9,5 +9,5 @@ The source of the search request.
 <b>Signature:</b>
 
 ```typescript
-querySource?: QuerySource;
+querySource?: QuerySource | string;
 ```

--- a/docs/answers-core.verticalsearchrequest.md
+++ b/docs/answers-core.verticalsearchrequest.md
@@ -24,7 +24,7 @@ export interface VerticalSearchRequest
 |  [offset?](./answers-core.verticalsearchrequest.offset.md) | number | <i>(Optional)</i> The result offset which allows for fetching more results with the same query. |
 |  [query](./answers-core.verticalsearchrequest.query.md) | string | The search query. |
 |  [queryId?](./answers-core.verticalsearchrequest.queryid.md) | string | <i>(Optional)</i> The queryId for the query, if this is a repeat query. |
-|  [querySource?](./answers-core.verticalsearchrequest.querysource.md) | [QuerySource](./answers-core.querysource.md) | <i>(Optional)</i> The source of the search request. |
+|  [querySource?](./answers-core.verticalsearchrequest.querysource.md) | [QuerySource](./answers-core.querysource.md) \| string | <i>(Optional)</i> The source of the search request. |
 |  [queryTrigger?](./answers-core.verticalsearchrequest.querytrigger.md) | [QueryTrigger](./answers-core.querytrigger.md) | <i>(Optional)</i> Describes the ways a search can be executed besides user input. |
 |  [referrerPageUrl?](./answers-core.verticalsearchrequest.referrerpageurl.md) | string | <i>(Optional)</i> The URl of the page which referred the user to the current page. |
 |  [retrieveFacets?](./answers-core.verticalsearchrequest.retrievefacets.md) | boolean | <i>(Optional)</i> Indicates that facets should be retrieved. |

--- a/docs/answers-core.verticalsearchrequest.querysource.md
+++ b/docs/answers-core.verticalsearchrequest.querysource.md
@@ -9,5 +9,5 @@ The source of the search request.
 <b>Signature:</b>
 
 ```typescript
-querySource?: QuerySource;
+querySource?: QuerySource | string;
 ```

--- a/etc/answers-core.api.md
+++ b/etc/answers-core.api.md
@@ -377,7 +377,7 @@ export interface UniversalSearchRequest {
     limit?: UniversalLimit;
     location?: LatLong;
     query: string;
-    querySource?: QuerySource;
+    querySource?: QuerySource | string;
     queryTrigger?: QueryTrigger;
     referrerPageUrl?: string;
     sessionId?: string;
@@ -423,7 +423,7 @@ export interface VerticalSearchRequest {
     offset?: number;
     query: string;
     queryId?: string;
-    querySource?: QuerySource;
+    querySource?: QuerySource | string;
     queryTrigger?: QueryTrigger;
     referrerPageUrl?: string;
     retrieveFacets?: boolean;

--- a/src/infra/SearchServiceImpl.ts
+++ b/src/infra/SearchServiceImpl.ts
@@ -34,7 +34,7 @@ interface UniversalSearchQueryParams extends QueryParams {
   queryTrigger?: QueryTrigger,
   context?: string;
   referrerPageUrl?: string,
-  source?: QuerySource
+  source?: QuerySource | string
 }
 
 /**
@@ -62,7 +62,7 @@ interface VerticalSearchQueryParams extends QueryParams {
   sortBys?: string,
   context?: string,
   referrerPageUrl?: string,
-  source?: QuerySource,
+  source?: QuerySource | string,
   locationRadius?: string,
   queryId?: string
 }

--- a/src/models/searchservice/request/UniversalSearchRequest.ts
+++ b/src/models/searchservice/request/UniversalSearchRequest.ts
@@ -33,7 +33,7 @@ export interface UniversalSearchRequest {
    */
   referrerPageUrl?: string;
   /** {@inheritDoc QuerySource} */
-  querySource?: QuerySource;
+  querySource?: QuerySource | string;
   /** {@inheritDoc UniversalLimit} */
   limit?: UniversalLimit;
 }

--- a/src/models/searchservice/request/VerticalSearchRequest.ts
+++ b/src/models/searchservice/request/VerticalSearchRequest.ts
@@ -44,7 +44,7 @@ export interface VerticalSearchRequest {
   /** {@inheritdoc UniversalSearchRequest.referrerPageUrl} */
   referrerPageUrl?: string,
   /** {@inheritDoc QuerySource} */
-  querySource?: QuerySource,
+  querySource?: QuerySource | string,
   /** The radius (in meters) to filter the vertical search by. */
   locationRadius?: number,
   /** The queryId for the query, if this is a repeat query. */

--- a/tests/infra/SearchServiceImpl.ts
+++ b/tests/infra/SearchServiceImpl.ts
@@ -123,6 +123,17 @@ describe('SearchService', () => {
       await searchService.universalSearch({query: 'test'});
       expect(mockHttpService.get).toHaveBeenCalledWith(customUrl, expect.anything());
     });
+
+    it('An arbitrary string may be supplied as a querySource', async () => {
+      await searchServiceWithRequiredParams.universalSearch({
+        query: 'test',
+        querySource: 'CUSTOM_SOURCE'
+      });
+      const expectedQueryParams = expect.objectContaining({
+        source: 'CUSTOM_SOURCE'
+      });
+      expect(mockHttpService.get).toHaveBeenCalledWith(expectedUniversalUrl, expectedQueryParams);
+    });
   });
 
   describe('Vertical Search', ()=> {


### PR DESCRIPTION
Allow an arbitrary string to be supplied as a query source for vertical and universal searches

This allows us to supply custom sources such as `SUPPORT_SEARCH`

J=SLAP-1438
TEST=manual, auto

Add a unit test for the functionality. Also use the core test site to supply arbitrary strings and observe it being sent in network requests