### PR TITLE
pass credentials: 'include' in get requests and simplify HttpService

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -59,7 +59,7 @@ THE SOFTWARE.
 
 The following NPM packages may be included in this product:
 
- - cross-fetch@3.0.6
+ - cross-fetch@3.1.4
 
 These packages each contain the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5244,16 +5244,6 @@
         "jest-util": "^26.6.2"
       }
     },
-    "jest-fetch-mock": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
-      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
-      "dev": true,
-      "requires": {
-        "cross-fetch": "^3.0.4",
-        "promise-polyfill": "^8.1.3"
-      }
-    },
     "jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
@@ -7044,12 +7034,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
-    },
-    "promise-polyfill": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
-      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
       "dev": true
     },
     "prompts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3159,9 +3159,9 @@
       "dev": true
     },
     "cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "requires": {
         "node-fetch": "2.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.12.5",
-    "cross-fetch": "^3.0.6"
+    "cross-fetch": "^3.1.4"
   },
   "jest": {
     "bail": 0,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "eslint": "^7.11.0",
     "generate-license-file": "^1.1.0",
     "jest": "^26.6.0",
-    "jest-fetch-mock": "^3.0.3",
     "ts-loader": "^8.0.14",
     "typescript": "^4.0.3",
     "webpack": "^5.18.0",
@@ -74,15 +73,11 @@
       "js",
       "ts"
     ],
-    "setupFilesAfterEnv": [
-      "./tests/setup/setup.js"
-    ],
     "moduleDirectories": [
       "node_modules",
       "<rootDir>"
     ],
     "testPathIgnorePatterns": [
-      "./tests/setup/setup.js",
       "./tests/mocks/*"
     ],
     "testMatch": [

--- a/src/infra/HttpServiceImpl.ts
+++ b/src/infra/HttpServiceImpl.ts
@@ -1,4 +1,4 @@
-import fetch from 'cross-fetch';
+import crossFetch from 'cross-fetch';
 import { addParamsToURL, sanitizeQueryParams } from '../utils/urlutils';
 import { QueryParams } from '../models/http/params';
 import { HttpService } from '../services/HttpService';
@@ -58,6 +58,9 @@ export class HttpServiceImpl implements HttpService {
     reqInit: RequestInit
   ): Promise<Response> {
     const urlWithParams = addParamsToURL(url, queryParams);
-    return fetch(urlWithParams, reqInit);
+    if (window.fetch) {
+      return window.fetch(urlWithParams, reqInit);
+    }
+    return crossFetch(urlWithParams, reqInit);
   }
 }

--- a/src/infra/HttpServiceImpl.ts
+++ b/src/infra/HttpServiceImpl.ts
@@ -22,14 +22,11 @@ export class HttpServiceImpl implements HttpService {
   get<T>(
     url: string,
     queryParams: QueryParams,
-    options?: RequestInit,
   ): Promise<T> {
-    const reqInitWithMethod = {
+    return this.fetch(url, queryParams, {
       method: RequestMethods.GET,
-      ...options
-    };
-    return this.fetch(url, queryParams, reqInitWithMethod)
-      .then(res => res.json());
+      credentials: 'include'
+    }).then(res => res.json());
   }
 
   /**
@@ -38,16 +35,17 @@ export class HttpServiceImpl implements HttpService {
   post<T>(
     url: string,
     queryParams: QueryParams,
-    body: QueryParams,
-    reqInit: RequestInit
+    body: QueryParams
   ): Promise<T> {
     const sanitizedBodyParams = sanitizeQueryParams(body);
-    const reqInitWithMethodAndBody = {
+    return this.fetch(url, queryParams, {
       method: RequestMethods.POST,
       body: JSON.stringify(sanitizedBodyParams),
-      ...reqInit
-    };
-    return this.fetch(url, queryParams, reqInitWithMethodAndBody)
+      mode: 'cors',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
       .then(res => res.json());
   }
 

--- a/src/infra/QuestionSubmissionServiceImpl.ts
+++ b/src/infra/QuestionSubmissionServiceImpl.ts
@@ -48,18 +48,10 @@ export class QuestionSubmissionServiceImpl implements QuestionSubmissionService 
       site: 'FIRSTPARTY'
     };
 
-    const requestInit = {
-      mode: 'cors' as RequestMode,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    };
-
     const response = await this.httpService.post<ApiResponse>(
       this.endpoint,
       queryParams,
-      body,
-      requestInit
+      body
     );
 
     const validationResult = this.apiResponseValidator.validate(response);

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -4,6 +4,6 @@ import { QueryParams } from '../models/http/params';
  * A service for HTTP Requests
  */
 export interface HttpService {
-  get<T>(url: string, queryParams: QueryParams, options?: RequestInit): Promise<T>;
-  post<T>(url: string, queryParams: QueryParams, body: QueryParams, reqInit: RequestInit): Promise<T>;
+  get<T>(url: string, queryParams: QueryParams): Promise<T>;
+  post<T>(url: string, queryParams: QueryParams, body: QueryParams): Promise<T>;
 }

--- a/tests/infra/HttpServiceImpl.js
+++ b/tests/infra/HttpServiceImpl.js
@@ -14,13 +14,10 @@ describe('HttpServiceImpl', () => {
     const queryParams = {
       aQuery: 'param'
     };
-    const reqInit = {
-      credentials: 'omit'
-    };
-    await httpServiceImpl.get('http://yext.com', queryParams, reqInit);
+    await httpServiceImpl.get('http://yext.com', queryParams);
     const expectedReqInit = {
       method: 'get',
-      credentials: 'omit'
+      credentials: 'include'
     };
     expect(fetch).toHaveBeenLastCalledWith('http://yext.com/?aQuery=param', expectedReqInit);
   });
@@ -32,14 +29,14 @@ describe('HttpServiceImpl', () => {
     const queryParams = {
       aQuery: 'param'
     };
-    const reqInit = {
-      credentials: 'include'
-    };
-    await httpServiceImpl.post('http://yext.com', queryParams, jsonBody, reqInit);
+    await httpServiceImpl.post('http://yext.com', queryParams, jsonBody);
     const expectedReqInit = {
       method: 'post',
       body: '{\"data\":\"123\"}',
-      credentials: 'include'
+      mode: 'cors',
+      headers: {
+        'Content-Type': 'application/json'
+      }
     };
     expect(fetch).toHaveBeenLastCalledWith('http://yext.com/?aQuery=param', expectedReqInit);
   });

--- a/tests/infra/QuestionSubmissionServiceImpl.ts
+++ b/tests/infra/QuestionSubmissionServiceImpl.ts
@@ -86,17 +86,6 @@ describe('Question submission', () => {
     expect(expectedBodyParams).toEqual(actualBodyParams);
   });
 
-  it('passed the right req init', () => {
-    const expectedReqInit = {
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      mode: 'cors'
-    };
-    const actualReqInit = actualHttpParams[3];
-    expect(actualReqInit).toEqual(expectedReqInit);
-  });
-
   it('parses the response correctly', () => {
     expect(response).toMatchObject({
       uuid: 'aUUID',

--- a/tests/setup/setup.js
+++ b/tests/setup/setup.js
@@ -1,7 +1,0 @@
-import fetchMock from 'jest-fetch-mock';
-
-fetchMock.enableMocks();
-
-beforeEach(() => {
-  fetch.resetMocks();
-});


### PR DESCRIPTION
GET requests were missing the credentials: 'include' header, which was
causing cookies to not be sent.

This commit
- changes HttpServiceImpl to no longer let you pass in specific overrides for RequestInit.
- Tries to use window.fetch if possible, which is what the SDK used to do. Before, we would always use cross-fetch, which will always use its whatwg-fetch ponyfill. It looks like there is some issue where using whatwg-fetch will prevent cookies from being displayed properly in the chrome/edge dev tools "Application -> Cookies" tab. 
   - Even with this change I can't get cookies to show up in Firefox/Safari dev tools, though they are still sent properly in the request. I also cannot get cookies to show up with SDK v1.7 on those browsers' dev tools so might be a personal browser settings thing.
- removes jest-fetch-mock because it was not needed after we added cross-fetch

Originally I intended for usages of HttpServiceImpl to manually pass
in request headers, and to not provide any defaults outside of the bare
minimum. Looking back, this added unneeded complexity to HttpService,
since all GET requests in 1.7 of answers-search-ui used the same headers,
and we only had one possible POST request.

T=TECHOPS-1384
TEST=manual

hooked up my local answers-core to answers-search-ui
saw that cookies were being sent in search requests, and that
question submission still had the same cors and content-type headers

tested on safari, chrome, firefox, edge, ie11