### PR TITLE
Update Question Submission Endpoint

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ export const defaultApiVersion = 20190101;
 export const defaultEndpoints: Required<Endpoints> = {
   universalSearch: 'https://liveapi.yext.com/v2/accounts/me/answers/query',
   verticalSearch: 'https://liveapi.yext.com/v2/accounts/me/answers/vertical/query',
-  questionSubmission: 'https://api.yext.com/v2/accounts/me/createQuestion',
+  questionSubmission: 'https://liveapi.yext.com/v2/accounts/me/createQuestion',
   status: 'https://answersstatus.pagescdn.com',
   universalAutocomplete: 'https://liveapi-cached.yext.com/v2/accounts/me/answers/autocomplete',
   verticalAutocomplete: 'https://liveapi-cached.yext.com/v2/accounts/me/answers/vertical/autocomplete',

--- a/tests/infra/QuestionSubmissionServiceImpl.ts
+++ b/tests/infra/QuestionSubmissionServiceImpl.ts
@@ -39,7 +39,7 @@ describe('Question submission', () => {
   });
 
   it('uses the production endpoint by default', () => {
-    const expectedUrl = 'https://api.yext.com/v2/accounts/me/createQuestion';
+    const expectedUrl = 'https://liveapi.yext.com/v2/accounts/me/createQuestion';
     const actualUrl = actualHttpParams[0];
     expect(expectedUrl).toEqual(actualUrl);
   });


### PR DESCRIPTION
Update the question submission endpoint from api.yext.com to liveapi.yext.com

J=SLAP-717
TEST=manual

Run a question submission query and see that the request goes to liveapi.yext.com and see that it works successfully