### PR TITLE
remove injectToStringMethods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Typescript Networking Library for the Yext Answers API",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",


### PR DESCRIPTION
injectToStringMethods does not work on objects that no longer
have the extensible property set to true. Specifically, it does not work
with a request.location provided by answers-headless, because answers-headless
uses immer for immutability on its state objects, which prevents additional properties
from being added to them after declaration.

J=SLAP-1591
TEST=manual

tested that I can do an Object.freeze() on request.location in the SearchServiceImpl
test, and things will work properly after this change (but will get the same "object is not
extensible" error before this change)

hook up local answers-core to an answers-headless page that sets request.location, see it work
properly