### PR TITLE
Fix node compatibility issue

### DIFF
--- a/src/infra/HttpServiceImpl.ts
+++ b/src/infra/HttpServiceImpl.ts
@@ -58,7 +58,7 @@ export class HttpServiceImpl implements HttpService {
     reqInit: RequestInit
   ): Promise<Response> {
     const urlWithParams = addParamsToURL(url, queryParams);
-    if (window.fetch) {
+    if (typeof(window) !== 'undefined' && window.fetch) {
       return window.fetch(urlWithParams, reqInit);
     }
     return crossFetch(urlWithParams, reqInit);

--- a/tests/infra/HttpServiceImpl.js
+++ b/tests/infra/HttpServiceImpl.js
@@ -50,6 +50,7 @@ describe('HttpServiceImpl', () => {
       nodeQuery: 'param'
     };
     await httpServiceImpl.get('http://yext.com', queryParams);
+    windowSpy.mockRestore();
 
     expect(fetch).toHaveBeenLastCalledWith('http://yext.com/?nodeQuery=param', expect.anything());
   });

--- a/tests/infra/HttpServiceImpl.js
+++ b/tests/infra/HttpServiceImpl.js
@@ -40,4 +40,17 @@ describe('HttpServiceImpl', () => {
     };
     expect(fetch).toHaveBeenLastCalledWith('http://yext.com/?aQuery=param', expectedReqInit);
   });
+
+  it('is compatible with node', async () => {
+    // Simulate a node environment where the window is undefined
+    const windowSpy = jest.spyOn(window, 'window', 'get');
+    windowSpy.mockImplementation(() => undefined);
+
+    const queryParams = {
+      nodeQuery: 'param'
+    };
+    await httpServiceImpl.get('http://yext.com', queryParams);
+
+    expect(fetch).toHaveBeenLastCalledWith('http://yext.com/?nodeQuery=param', expect.anything());
+  });
 });


### PR DESCRIPTION
Fix the window access issue which was causing the library to break on node

I added a unit test which ensures that the HttpService works on node

J=none
TEST=manual, auto

Test on the browser and on node and confirm searches work on both