### PR TITLE
fix engine field in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.3.2",
+  "version": "1.3.3-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-core",
-      "version": "1.3.2",
+      "version": "1.3.3-beta.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
@@ -33,7 +33,7 @@
         "webpack-cli": "^4.4.0"
       },
       "engines": {
-        "node": ">=0.12"
+        "node": ">=12"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=0.12"
+    "node": ">=12"
   },
   "scripts": {
     "test": "npm run lint && jest",


### PR DESCRIPTION
This was intended to be set to node 12 and up, since we use
Array.prototype.flatMap, see #21.

J=none
TEST=manual

tried doing a local install on node 11, with the --engine-strict flag
npm refused to install answers-core