### PR TITLE
Change how the `Visitor` params are included in API requests.

### DIFF
--- a/src/infra/AutocompleteServiceImpl.ts
+++ b/src/infra/AutocompleteServiceImpl.ts
@@ -70,7 +70,8 @@ export class AutocompleteServiceImpl implements AutocompleteService {
       version: this.config.experienceVersion,
       locale: this.config.locale,
       sessionTrackingEnabled: request.sessionTrackingEnabled,
-      visitor: JSON.stringify(this.config.visitor),
+      visitorId: this.config.visitor?.id,
+      visitorIdMethod: this.config.visitor?.idMethod,
       ...this.config?.additionalQueryParams
     };
 
@@ -103,7 +104,8 @@ export class AutocompleteServiceImpl implements AutocompleteService {
       locale: this.config.locale,
       verticalKey: request.verticalKey,
       sessionTrackingEnabled: request.sessionTrackingEnabled,
-      visitor: JSON.stringify(this.config.visitor),
+      visitorId: this.config.visitor?.id,
+      visitorIdMethod: this.config.visitor?.idMethod,
       ...this.config?.additionalQueryParams
     };
 
@@ -141,7 +143,8 @@ export class AutocompleteServiceImpl implements AutocompleteService {
       search_parameters: JSON.stringify(searchParams),
       verticalKey: request.verticalKey,
       sessionTrackingEnabled: request.sessionTrackingEnabled,
-      visitor: JSON.stringify(this.config.visitor),
+      visitorId: this.config.visitor?.id,
+      visitorIdMethod: this.config.visitor?.idMethod,
       ...this.config?.additionalQueryParams
     };
 

--- a/src/infra/SearchServiceImpl.ts
+++ b/src/infra/SearchServiceImpl.ts
@@ -113,7 +113,8 @@ export class SearchServiceImpl implements SearchService {
       context: JSON.stringify(request.context),
       referrerPageUrl: request.referrerPageUrl,
       source: request.querySource || QuerySource.Standard,
-      visitor: JSON.stringify(this.config.visitor),
+      visitorId: this.config.visitor?.id,
+      visitorIdMethod: this.config.visitor?.idMethod,
       ...this.config?.additionalQueryParams
     };
 
@@ -157,7 +158,8 @@ export class SearchServiceImpl implements SearchService {
       source: request.querySource || QuerySource.Standard,
       locationRadius: request.locationRadius?.toString(),
       queryId: request.queryId,
-      visitor: JSON.stringify(this.config.visitor),
+      visitorId: this.config.visitor?.id,
+      visitorIdMethod: this.config.visitor?.idMethod,
       ...this.config?.additionalQueryParams
     };
 

--- a/src/models/autocompleteservice/AutocompleteQueryParams.ts
+++ b/src/models/autocompleteservice/AutocompleteQueryParams.ts
@@ -8,5 +8,6 @@ export interface AutocompleteQueryParams extends QueryParams {
   version?: string | number,
   locale?: string,
   sessionTrackingEnabled?: boolean,
-  visitor?: string
+  visitorId?: string,
+  visitorIdMethod?: string,
 }

--- a/tests/infra/AutoCompleteServiceImpl.ts
+++ b/tests/infra/AutoCompleteServiceImpl.ts
@@ -62,10 +62,8 @@ describe('AutocompleteService', () => {
         v: 20190101,
         locale: 'en',
         sessionTrackingEnabled: false,
-        visitor: JSON.stringify({
-          id: '123',
-          idMethod: 'YEXT_AUTH'
-        })
+        visitorId: '123',
+        visitorIdMethod: 'YEXT_AUTH'
       };
       const autocompleteService = new AutocompleteServiceImpl(
         config,
@@ -124,10 +122,8 @@ describe('AutocompleteService', () => {
         locale: 'en',
         sessionTrackingEnabled: false,
         verticalKey: 'verticalKey',
-        visitor: JSON.stringify({
-          id: '123',
-          idMethod: 'YEXT_AUTH'
-        })
+        visitorId: '123',
+        visitorIdMethod: 'YEXT_AUTH'
       };
       const autocompleteService = new AutocompleteServiceImpl(
         config,
@@ -186,10 +182,8 @@ describe('AutocompleteService', () => {
         sessionTrackingEnabled: false,
         verticalKey: 'verticalKey',
         search_parameters: JSON.stringify(convertedSearchParams),
-        visitor: JSON.stringify({
-          id: '123',
-          idMethod: 'YEXT_AUTH'
-        })
+        visitorId: '123',
+        visitorIdMethod: 'YEXT_AUTH'
       };
       const autocompleteService = new AutocompleteServiceImpl(
         config,

--- a/tests/infra/SearchServiceImpl.ts
+++ b/tests/infra/SearchServiceImpl.ts
@@ -137,10 +137,8 @@ describe('SearchService', () => {
         v: 20190101,
         version: 'PRODUCTION',
         source: 'STANDARD',
-        visitor: JSON.stringify({
-          id: '123',
-          idMethod: 'YEXT_AUTH'
-        })
+        visitorId: '123',
+        visitorIdMethod: 'YEXT_AUTH'
       };
       await searchServiceWithAllParams.universalSearch(requestWithAllParams);
       expect(mockHttpService.get)
@@ -290,10 +288,8 @@ describe('SearchService', () => {
         v: 20190101,
         version: 'PRODUCTION',
         verticalKey: 'verticalKey',
-        visitor: JSON.stringify({
-          id: '123',
-          idMethod: 'YEXT_AUTH'
-        })
+        visitorId: '123',
+        visitorIdMethod: 'YEXT_AUTH'
       };
       await searchServiceWithAllParams.verticalSearch(requestWithAllParams);
       expect(mockHttpService.get).toHaveBeenCalledWith(expectedVerticalUrl, expectedQueryParams, undefined);


### PR DESCRIPTION
Originally, the spec called for the `Visitor` object to be passed as a single
param in the Live API requests. Now, the spec has been updated so that each
attribute of the `Visitor` is passed as its own top-level API param.

J=SLAP-1686
TEST=auto

Updated the unit tests and ensured they passed.