### PR TITLE
Add query source

### DIFF
--- a/docs/answers-core.querysource.md
+++ b/docs/answers-core.querysource.md
@@ -16,6 +16,7 @@ export declare enum QuerySource
 
 |  Member | Value | Description |
 |  --- | --- | --- |
+|  Autocomplete | <code>&quot;AUTOCOMPLETE&quot;</code> | Indicates that the query was initiated from visual autocomplete. |
 |  Overlay | <code>&quot;OVERLAY&quot;</code> | Indicates that the query was initaited from an Answers Overlay. |
 |  Standard | <code>&quot;STANDARD&quot;</code> | Indicates that the query was initiated from a standard Answers integration. |
 

--- a/etc/answers-core.api.md
+++ b/etc/answers-core.api.md
@@ -274,6 +274,7 @@ export function provideCore(config: AnswersConfig): AnswersCore;
 
 // @public
 export enum QuerySource {
+    Autocomplete = "AUTOCOMPLETE",
     Overlay = "OVERLAY",
     Standard = "STANDARD"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.5.0-beta.1",
+  "version": "1.6.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-core",
-      "version": "1.5.0-beta.1",
+      "version": "1.6.0-beta.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.5.0-beta.1",
+  "version": "1.6.0-beta.0",
   "description": "Typescript Networking Library for the Yext Answers API",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",

--- a/src/models/searchservice/request/QuerySource.ts
+++ b/src/models/searchservice/request/QuerySource.ts
@@ -11,5 +11,9 @@ export enum QuerySource {
   /**
    * Indicates that the query was initaited from an Answers Overlay.
    */
-  Overlay = 'OVERLAY'
+  Overlay = 'OVERLAY',
+  /**
+   * Indicates that the query was initiated from visual autocomplete.
+   */
+  Autocomplete = 'AUTOCOMPLETE'
 }


### PR DESCRIPTION
Add 'AUTOCOMPLETE' as a `QuerySource` for when visual autocomplete hits the universal endpoint.

J=SLAP-1801
TEST=none