### PR TITLE
track src directory in npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-core",
-      "version": "1.6.0-beta.1",
+      "version": "1.6.0-beta.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0-beta.2",
   "description": "Typescript Networking Library for the Yext Answers API",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",
@@ -8,7 +8,8 @@
   "files": [
     "dist",
     "legacy",
-    "lib"
+    "lib",
+    "src"
   ],
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
In order for source maps to work properly, the original source code needs to be present in the npm package.
Adds the "src" folder to the package.json's files property so these are tracked by npm.

J=SLAP-1798
TEST=manual

test that if I use a local answers-core, answers-headless, and answers-headless-react, which all have their respective "src" directories due to being local, answers-headless-react can be used with create-react-app v5
without this, get errors like the below
![image](https://user-images.githubusercontent.com/23005393/152199966-82cfda34-bc53-47a9-b2d8-6fef0ddc9b43.png)

if I only use a local answers-headless-react and answers-headless, but the current beta version of answers-core, the error message will complain about an answers-core src file not existing
