### PR TITLE
Update defaultApiVersion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@yext/answers-core",
-      "version": "1.6.0-beta.5",
+      "version": "1.6.0-beta.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import { Endpoints } from './models/core/Endpoints';
 
-export const defaultApiVersion = 20190101;
+export const defaultApiVersion = 20220511;
 
 export const defaultEndpoints: Required<Endpoints> = {
   universalSearch: 'https://liveapi.yext.com/v2/accounts/me/answers/query',

--- a/tests/infra/AutocompleteServiceImpl.ts
+++ b/tests/infra/AutocompleteServiceImpl.ts
@@ -11,7 +11,7 @@ import mockAutocompleteResponse from '../fixtures/autocompleteresponse.json';
 import mockAutocompleteResponseWithSections from '../fixtures/autocompleteresponsewithsections.json';
 import mockAutocompleteResponseWithFailedVerticals from '../fixtures/autocompleteresponsewithfailedverticals.json';
 import mockAutocompleteResponseWithVerticalKeys from '../fixtures/autocompleteresponsewithverticalkeys.json';
-import { defaultEndpoints } from '../../src/constants';
+import { defaultEndpoints, defaultApiVersion } from '../../src/constants';
 import { ApiResponseValidator } from '../../src/validation/ApiResponseValidator';
 import { ApiResponse } from '../../src/models/answersapi/ApiResponse';
 import { AnswersError } from '../../src/models/answersapi/AnswersError';
@@ -59,7 +59,7 @@ describe('AutocompleteService', () => {
       input: '',
       experienceKey: 'testExperienceKey',
       api_key: 'testApiKey',
-      v: 20190101,
+      v: defaultApiVersion,
       locale: 'en',
       sessionTrackingEnabled: false,
       visitorId: '123',
@@ -84,7 +84,7 @@ describe('AutocompleteService', () => {
         input: '',
         experienceKey: 'testExperienceKey',
         api_key: 'testApiKey',
-        v: 20190101,
+        v: defaultApiVersion,
         locale: 'en',
         sessionTrackingEnabled: false
       };
@@ -135,7 +135,7 @@ describe('AutocompleteService', () => {
       input: 'salesforce',
       experienceKey: 'testExperienceKey',
       api_key: 'testApiKey',
-      v: 20190101,
+      v: defaultApiVersion,
       locale: 'en',
       sessionTrackingEnabled: false,
       verticalKey: 'verticalKey'
@@ -151,7 +151,7 @@ describe('AutocompleteService', () => {
         input: 'salesforce',
         experienceKey: 'testExperienceKey',
         api_key: 'testApiKey',
-        v: 20190101,
+        v: defaultApiVersion,
         locale: 'en',
         sessionTrackingEnabled: false,
         verticalKey: 'verticalKey',
@@ -200,7 +200,7 @@ describe('AutocompleteService', () => {
         input: 'salesforce',
         experienceKey: 'testExperienceKey',
         api_key: 'testApiKey',
-        v: 20190101,
+        v: defaultApiVersion,
         locale: 'en',
         sessionTrackingEnabled: false,
         verticalKey: 'verticalKey',

--- a/tests/infra/QuestionSubmissionServiceImpl.ts
+++ b/tests/infra/QuestionSubmissionServiceImpl.ts
@@ -3,6 +3,7 @@ import { HttpServiceMock } from '../mocks/HttpServiceMock';
 import { HttpService } from '../../src/services/HttpService';
 import { AnswersConfig } from '../../src/models/core/AnswersConfig';
 import { ApiResponseValidator } from '../../src/validation/ApiResponseValidator';
+import { defaultApiVersion } from '../../src/constants';
 
 const baseCoreConfig = {
   apiKey: 'anApiKey',
@@ -67,7 +68,7 @@ describe('Question submission', () => {
     const expectedQueryParams = {
       api_key: 'anApiKey',
       sessionTrackingEnabled: true,
-      v: 20190101
+      v: defaultApiVersion
     };
     const actualQueryParams = actualHttpParams[1];
     expect(expectedQueryParams).toEqual(actualQueryParams);

--- a/tests/infra/SearchServiceImpl.ts
+++ b/tests/infra/SearchServiceImpl.ts
@@ -11,6 +11,7 @@ import { Matcher } from '../../src/models/searchservice/common/Matcher';
 import { Direction } from '../../src/models/searchservice/request/Direction';
 import { SortType } from '../../src/models/searchservice/request/SortType';
 import { getClientSdk } from '../../src/utils/getClientSdk';
+import { defaultApiVersion } from '../../src/constants';
 
 describe('SearchService', () => {
   const configWithRequiredApiKey: AnswersConfig = {
@@ -81,7 +82,7 @@ describe('SearchService', () => {
         experienceKey: 'testExperienceKey',
         input: 'testQuery',
         locale: 'en',
-        v: 20190101,
+        v: defaultApiVersion,
         source: 'STANDARD'
       };
       await searchServiceWithRequiredApiKey.universalSearch(requestWithRequiredParams);
@@ -97,7 +98,7 @@ describe('SearchService', () => {
         experienceKey: 'testExperienceKey',
         input: 'testQuery',
         locale: 'en',
-        v: 20190101,
+        v: defaultApiVersion,
         source: 'STANDARD'
       };
       await searchServiceWithRequiredToken.universalSearch(requestWithRequiredParams);
@@ -137,7 +138,7 @@ describe('SearchService', () => {
         session_id: '8ad0cb51-82f6-4ad9-bc62-b358115fde30',
         sessionTrackingEnabled: true,
         skipSpellCheck: true,
-        v: 20190101,
+        v: defaultApiVersion,
         version: 'PRODUCTION',
         source: 'STANDARD',
         visitorId: '123',
@@ -208,7 +209,7 @@ describe('SearchService', () => {
         verticalKey: 'verticalKey',
         input: 'testQuery',
         locale: 'en',
-        v: 20190101,
+        v: defaultApiVersion,
         source: 'STANDARD',
         sortBys: '[]',
       };
@@ -227,7 +228,7 @@ describe('SearchService', () => {
         verticalKey: 'verticalKey',
         input: 'testQuery',
         locale: 'en',
-        v: 20190101,
+        v: defaultApiVersion,
         source: 'STANDARD',
         sortBys: '[]',
       };
@@ -307,7 +308,7 @@ describe('SearchService', () => {
           type: 'FIELD'
         }]),
         source: 'STANDARD',
-        v: 20190101,
+        v: defaultApiVersion,
         version: 'PRODUCTION',
         verticalKey: 'verticalKey',
         visitorId: '123',


### PR DESCRIPTION
Update the `defaultApiVersion` to match the v param for the new LiveApi version that will support number range facets.

J=SLAP-2024
TEST=auto, manual

Check that updated Jest tests pass. Use the Core test-site and see that the updated v param is passed with each request and all endpoints (except for question submission) return a 200 status.

Once the backend work was done, performed a full end-to-end test and saw that the component lib test-site using Core locally passed the new v param and had number range facets returned in the response. The same site using Core from NPM passed the old v param and did not have number range facets returned.