### PR TITLE
Bump version to v1.6.0-beta.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.6.0-beta.7",
+  "version": "1.6.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-core",
-      "version": "1.6.0-beta.7",
+      "version": "1.6.0-beta.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-core",
-  "version": "1.6.0-beta.7",
+  "version": "1.6.0-beta.8",
   "description": "Typescript Networking Library for the Yext Answers API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",


### PR DESCRIPTION
Bumps the beta version to incorporate the changes from reverting the `FilterSearchResponse` updates (#112). These updates will not be part of v1.6.0.