### PR TITLE
chore: mention max length for visitor idmethod in docs

### DIFF
--- a/docs/search-core.visitor.idmethod.md
+++ b/docs/search-core.visitor.idmethod.md
@@ -4,7 +4,7 @@
 
 ## Visitor.idMethod property
 
-The type of visitor
+The type of visitor. Max of 16 characters.
 
 **Signature:**
 

--- a/docs/search-core.visitor.md
+++ b/docs/search-core.visitor.md
@@ -73,7 +73,7 @@ string
 
 </td><td>
 
-_(Optional)_ The type of visitor
+_(Optional)_ The type of visitor. Max of 16 characters.
 
 
 </td></tr>

--- a/src/models/core/Visitor.ts
+++ b/src/models/core/Visitor.ts
@@ -9,7 +9,7 @@
 export interface Visitor {
   /** The ID associated with the user */
   id: string,
-  /** The type of visitor
+  /** The type of visitor. Max of 16 characters.
    *
    * @example 'YEXT_USER' for Yext Auth
    */


### PR DESCRIPTION
Updating the docs to mention that the max length of the visitor idmethod is 16 (taken from Snowflake table). Not planning on making a new release for this, and will instead wait for the next release to pick up this change.